### PR TITLE
feat: Issue #7 日報詳細・更新・提出APIを実装する（GET/PUT /reports/:id, POST /reports/:id/submit）

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyToken } from "@/src/lib/auth/jwt";
+import { isBlacklisted } from "@/src/lib/auth/token-blacklist";
+
+/**
+ * Next.js ミドルウェア。
+ *
+ * `/api/auth/login` 以外の全 `/api/**` ルートに適用し、
+ * Bearer トークンを検証する。
+ *
+ * - トークン未指定 → 401 UNAUTHORIZED
+ * - ブラックリスト済み → 401 UNAUTHORIZED
+ * - 不正・期限切れトークン → 401 UNAUTHORIZED
+ * - 有効なトークン → リクエストをそのまま通す
+ */
+export async function middleware(req: NextRequest): Promise<NextResponse> {
+  const authorization = req.headers.get("authorization");
+
+  if (!authorization || !authorization.startsWith("Bearer ")) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "UNAUTHORIZED",
+          message: "認証トークンが指定されていません",
+        },
+      },
+      { status: 401 },
+    );
+  }
+
+  const token = authorization.slice(7).trim();
+
+  if (!token) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "UNAUTHORIZED",
+          message: "認証トークンが指定されていません",
+        },
+      },
+      { status: 401 },
+    );
+  }
+
+  if (isBlacklisted(token)) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "UNAUTHORIZED",
+          message: "無効なトークンです",
+        },
+      },
+      { status: 401 },
+    );
+  }
+
+  try {
+    await verifyToken(token);
+  } catch {
+    return NextResponse.json(
+      {
+        error: {
+          code: "UNAUTHORIZED",
+          message: "トークンが無効または期限切れです",
+        },
+      },
+      { status: 401 },
+    );
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    /*
+     * `/api/auth/login` を除く全ての `/api/**` パスに適用する。
+     * Next.js の matcher は正規表現ではなく glob パターン。
+     * 否定先読みは使えないため、negative matcher を使う。
+     */
+    "/api/((?!auth/login).*)",
+  ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,18 @@
       "name": "nippo",
       "version": "0.1.0",
       "dependencies": {
+        "@prisma/adapter-pg": "^7.6.0",
+        "@prisma/client": "^7.6.0",
+        "@types/bcryptjs": "^2.4.6",
+        "@types/pg": "^8.20.0",
+        "bcryptjs": "^3.0.3",
+        "jose": "^6.2.2",
         "next": "16.2.1",
+        "pg": "^8.20.0",
+        "prisma": "^7.6.0",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
@@ -365,6 +374,27 @@
         "specificity": "bin/cli.js"
       }
     },
+    "node_modules/@clack/core": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.5.0.tgz",
+      "integrity": "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==",
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.11.0.tgz",
+      "integrity": "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "0.5.0",
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
@@ -503,6 +533,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@electric-sql/pglite": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
+      "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@electric-sql/pglite-socket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.1.1.tgz",
+      "integrity": "sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "pglite-server": "dist/scripts/server.js"
+      },
+      "peerDependencies": {
+        "@electric-sql/pglite": "0.4.1"
+      }
+    },
+    "node_modules/@electric-sql/pglite-tools": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.3.1.tgz",
+      "integrity": "sha512-C+T3oivmy9bpQvSxVqXA1UDY8cB9Eb9vZHL9zxWwEUfDixbXv4G3r2LjoTdR33LD8aomR3O9ZXEO3XEwr/cUCA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@electric-sql/pglite": "0.4.1"
       }
     },
     "node_modules/@emnapi/core": {
@@ -698,6 +755,18 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1356,6 +1425,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@mswjs/interceptors": {
       "version": "0.41.3",
       "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
@@ -1612,6 +1687,371 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@prisma/adapter-pg": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.6.0.tgz",
+      "integrity": "sha512-BjHNmJqqa42NqJSDPnXUfwUofWo8LJY7Ui2gqxN4DmAOb+H/gGKv+hln2Xq/1kSJXPW5AXMXuNiPDMpywvyIOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/driver-adapter-utils": "7.6.0",
+        "@types/pg": "^8.16.0",
+        "pg": "^8.16.3",
+        "postgres-array": "3.0.4"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.6.0.tgz",
+      "integrity": "sha512-7Pe/1ayh3GgWPEg4mmT4ax77LJ1wC+XlnIFvQ94bLP2DsUnOpnruQQR3Jw7r+Frthk94QqDNxo3FjSg8h9PXeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/client-runtime-utils": "7.6.0"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24.0"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/client-runtime-utils": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client-runtime-utils/-/client-runtime-utils-7.6.0.tgz",
+      "integrity": "sha512-fD7jlqubsZvVODKvsp9lOpXVecx2aWGxC2l35Ioz2t+teUJ5CfR0SAMsi7UkU1VvaZmmm+DS6BdujF622nY7tQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/config": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.6.0.tgz",
+      "integrity": "sha512-MuAz1MK4PeG5/03YzfzX3CnFVHQ6qePGwUpQRzPzX5tT0ffJ3Tzi9zJZbBc+VzEGFCM8ghW/gTVDR85Syjt+Yw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "c12": "3.1.0",
+        "deepmerge-ts": "7.1.5",
+        "effect": "3.20.0",
+        "empathic": "2.0.0"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.6.0.tgz",
+      "integrity": "sha512-LpHr3qos4lQZ6sxwjStf59YBht7m9/QF7NSQsMH6qGENWZu2w3UkQUGn1h5iRkDjnWRj3VHykOu9qFhps4ADvA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/dev": {
+      "version": "0.24.3",
+      "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.3.tgz",
+      "integrity": "sha512-ffHlQuKXZiaDt9Go0OnCTdJZrHxK0k7omJKNV86/VjpsXu5EIHZLK0T7JSWgvNlJwh56kW9JFu9v0qJciFzepg==",
+      "license": "ISC",
+      "dependencies": {
+        "@electric-sql/pglite": "0.4.1",
+        "@electric-sql/pglite-socket": "0.1.1",
+        "@electric-sql/pglite-tools": "0.3.1",
+        "@hono/node-server": "1.19.11",
+        "@prisma/get-platform": "7.2.0",
+        "@prisma/query-plan-executor": "7.2.0",
+        "@prisma/streams-local": "0.1.2",
+        "foreground-child": "3.3.1",
+        "get-port-please": "3.2.0",
+        "hono": "^4.12.8",
+        "http-status-codes": "2.3.0",
+        "pathe": "2.0.3",
+        "proper-lockfile": "4.1.2",
+        "remeda": "2.33.4",
+        "std-env": "3.10.0",
+        "valibot": "1.2.0",
+        "zeptomatch": "2.1.0"
+      }
+    },
+    "node_modules/@prisma/dev/node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "license": "MIT"
+    },
+    "node_modules/@prisma/driver-adapter-utils": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.6.0.tgz",
+      "integrity": "sha512-D8j3p0RnhLuufMaRLX6QqtGgPC5Ao3l5oFP6Q5AL0rTHi4vna+NzGEipwCsfvcSvaGFCbsH3lsTMbb4WvY+ovA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.6.0"
+      }
+    },
+    "node_modules/@prisma/engines": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.6.0.tgz",
+      "integrity": "sha512-Sn5edRzhHqgRV2M+A0eIbY442B4mReWWf3pKs/LKreYgW7oa/up8JtK/s4iv/EQA097cyboZ08mmkpbLp+tZ3w==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.6.0",
+        "@prisma/engines-version": "7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711",
+        "@prisma/fetch-engine": "7.6.0",
+        "@prisma/get-platform": "7.6.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711.tgz",
+      "integrity": "sha512-r51DLcJ8bDRSrBEJF3J4cinoWyGA7rfP2mG6lD90VqIbGNOkbfcLcXalSVjq5Y6brQS3vcjrq4GbyUb1Cb7vkw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.6.0.tgz",
+      "integrity": "sha512-ohZDwXvtmnbzOcutR2D13lDWpZP1wQjmPyztmt0AwXLzQI7q95EE7NYCvS+M6N6SivT+BM0NOqLmTH3wms4L3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.6.0"
+      }
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.6.0.tgz",
+      "integrity": "sha512-N575Ni95c3FkduWY/eKTHqNYgNbceZ1tQaSknVtJjpKmiiBXmniESn/GTxsDvICC4ZeiNrXxioGInzQrCdx16w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.6.0",
+        "@prisma/engines-version": "7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711",
+        "@prisma/get-platform": "7.6.0"
+      }
+    },
+    "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.6.0.tgz",
+      "integrity": "sha512-ohZDwXvtmnbzOcutR2D13lDWpZP1wQjmPyztmt0AwXLzQI7q95EE7NYCvS+M6N6SivT+BM0NOqLmTH3wms4L3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.6.0"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.2.0.tgz",
+      "integrity": "sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "7.2.0"
+      }
+    },
+    "node_modules/@prisma/get-platform/node_modules/@prisma/debug": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.2.0.tgz",
+      "integrity": "sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/query-plan-executor": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@prisma/query-plan-executor/-/query-plan-executor-7.2.0.tgz",
+      "integrity": "sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/streams-local": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@prisma/streams-local/-/streams-local-0.1.2.tgz",
+      "integrity": "sha512-l49yTxKKF2odFxaAXTmwmkBKL3+bVQ1tFOooGifu4xkdb9NMNLxHj27XAhTylWZod8I+ISGM5erU1xcl/oBCtg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "better-result": "^2.7.0",
+        "env-paths": "^3.0.0",
+        "proper-lockfile": "^4.1.2"
+      },
+      "engines": {
+        "bun": ">=1.3.6",
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@prisma/streams-local/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@prisma/streams-local/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@prisma/studio-core": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.27.3.tgz",
+      "integrity": "sha512-AADjNFPdsrglxHQVTmHFqv6DuKQZ5WY4p5/gVFY017twvNrSwpLJ9lqUbYYxEu2W7nbvVxTZA8deJ8LseNALsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@radix-ui/react-toggle": "1.1.10",
+        "chart.js": "4.5.1"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24.0",
+        "pnpm": "8"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1906,7 +2346,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -2038,6 +2477,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2081,17 +2526,26 @@
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2101,7 +2555,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -3119,6 +3573,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/axe-core": {
       "version": "4.11.2",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.2.tgz",
@@ -3156,6 +3619,27 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    },
+    "node_modules/better-result": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.7.0.tgz",
+      "integrity": "sha512-7zrmXjAK8u8Z6SOe4R65XObOR5X+Y2I/VVku3t5cPOGQ8/WsBcfFmfnIPiEl5EBMDOzPHRwbiPbMtQBKYdw7RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/prompts": "^0.11.0"
+      },
+      "bin": {
+        "better-result": "bin/cli.mjs"
       }
     },
     "node_modules/bidi-js": {
@@ -3224,6 +3708,34 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/c12": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
+      "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.3",
+        "confbox": "^0.2.2",
+        "defu": "^6.1.4",
+        "dotenv": "^16.6.1",
+        "exsolve": "^1.0.7",
+        "giget": "^2.0.0",
+        "jiti": "^2.4.2",
+        "ohash": "^2.0.11",
+        "pathe": "^2.0.3",
+        "perfect-debounce": "^1.0.0",
+        "pkg-types": "^2.2.0",
+        "rc9": "^2.1.2"
+      },
+      "peerDependencies": {
+        "magicast": "^0.3.5"
+      },
+      "peerDependenciesMeta": {
+        "magicast": {
+          "optional": true
+        }
       }
     },
     "node_modules/call-bind": {
@@ -3331,6 +3843,42 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/citty": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.2.3"
       }
     },
     "node_modules/cli-cursor": {
@@ -3505,6 +4053,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/confbox": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3530,7 +4093,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -3566,7 +4128,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -3676,6 +4237,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge-ts": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -3712,6 +4282,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/defu": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.6.tgz",
+      "integrity": "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==",
+      "license": "MIT"
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3722,6 +4307,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -3754,6 +4345,18 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3767,6 +4370,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/effect": {
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.20.0.tgz",
+      "integrity": "sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -3783,6 +4396,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/empathic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+      "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -3794,6 +4416,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/environment": {
@@ -4490,11 +5124,38 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/exsolve": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -4540,6 +5201,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -4631,6 +5308,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -4685,6 +5378,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
       }
     },
     "node_modules/generator-function": {
@@ -4755,6 +5457,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-port-please": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
+      "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==",
+      "license": "MIT"
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -4798,6 +5506,23 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/giget": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
+      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.1.6",
+        "consola": "^3.4.0",
+        "defu": "^6.1.4",
+        "node-fetch-native": "^1.6.6",
+        "nypm": "^0.6.0",
+        "pathe": "^2.0.3"
+      },
+      "bin": {
+        "giget": "dist/cli.mjs"
       }
     },
     "node_modules/glob-parent": {
@@ -4855,6 +5580,24 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/grammex": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.12.tgz",
+      "integrity": "sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==",
+      "license": "MIT"
+    },
+    "node_modules/graphmatch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/graphmatch/-/graphmatch-1.1.1.tgz",
+      "integrity": "sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==",
+      "license": "MIT"
     },
     "node_modules/graphql": {
       "version": "16.13.2",
@@ -4984,6 +5727,15 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.10",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
+      "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -4996,6 +5748,12 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
+      "license": "MIT"
     },
     "node_modules/husky": {
       "version": "9.1.7",
@@ -5011,6 +5769,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -5369,6 +6143,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5525,7 +6305,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -5544,6 +6323,24 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -6286,6 +7083,12 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -6307,6 +7110,21 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
       }
     },
     "node_modules/lz-string": {
@@ -6479,6 +7297,38 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/mysql2": {
+      "version": "3.15.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.3.tgz",
+      "integrity": "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==",
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.1",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.0",
+        "long": "^5.2.1",
+        "lru.min": "^1.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+      "license": "MIT",
+      "dependencies": {
+        "lru.min": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -6592,11 +7442,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nypm": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
+      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "citty": "^0.2.0",
+        "pathe": "^2.0.3",
+        "tinyexec": "^1.0.2"
+      },
+      "bin": {
+        "nypm": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/nypm/node_modules/citty": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -6733,6 +7612,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/ohash": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+      "license": "MIT"
+    },
     "node_modules/onetime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -6864,7 +7749,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6888,8 +7772,111 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg-types/node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6908,6 +7895,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.2",
+        "exsolve": "^1.0.7",
+        "pathe": "^2.0.3"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -6946,6 +7944,58 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.7.tgz",
+      "integrity": "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
+      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -7091,6 +8141,39 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/prisma": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.6.0.tgz",
+      "integrity": "sha512-OKJIPT81K3+F+AayIkY/Y3mkF2NWoFh7lZApaaqPYy7EHILKdO0VsmGkP+hDKYTySHsFSyLWXm/JgcR1B8fY1Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "7.6.0",
+        "@prisma/dev": "0.24.3",
+        "@prisma/engines": "7.6.0",
+        "@prisma/studio-core": "0.27.3",
+        "mysql2": "3.15.3",
+        "postgres": "3.4.7"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24.0"
+      },
+      "peerDependencies": {
+        "better-sqlite3": ">=9.0.0",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "better-sqlite3": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7103,6 +8186,23 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -7112,6 +8212,22 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -7133,6 +8249,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/rc9": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "destr": "^2.0.3"
+      }
     },
     "node_modules/react": {
       "version": "19.2.4",
@@ -7161,6 +8287,19 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -7220,6 +8359,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/remeda": {
+      "version": "2.33.4",
+      "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.33.4.tgz",
+      "integrity": "sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/remeda"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7234,7 +8382,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7296,6 +8443,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rettime": {
@@ -7443,6 +8599,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -7471,6 +8633,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -7583,7 +8750,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -7596,7 +8762,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7689,7 +8854,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -7697,6 +8861,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "license": "MIT"
     },
     "node_modules/slice-ansi": {
       "version": "8.0.0",
@@ -7751,6 +8921,24 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/stable-hash": {
@@ -8086,7 +9274,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
       "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -8365,7 +9552,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -8432,7 +9619,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -8519,6 +9705,20 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
+      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite": {
@@ -8788,7 +9988,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -8948,6 +10147,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -9036,11 +10244,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zeptomatch": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/zeptomatch/-/zeptomatch-2.1.0.tgz",
+      "integrity": "sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==",
+      "license": "MIT",
+      "dependencies": {
+        "grammex": "^3.1.11",
+        "graphmatch": "^1.1.0"
+      }
+    },
     "node_modules/zod": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -17,13 +17,27 @@
     "prepare": "cd .. && git config core.hooksPath nippo/.husky"
   },
   "lint-staged": {
-    "*.{ts,tsx}": ["eslint --fix", "prettier --write"],
-    "*.{json,css}": ["prettier --write"]
+    "*.{ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{json,css}": [
+      "prettier --write"
+    ]
   },
   "dependencies": {
+    "@prisma/adapter-pg": "^7.6.0",
+    "@prisma/client": "^7.6.0",
+    "@types/bcryptjs": "^2.4.6",
+    "@types/pg": "^8.20.0",
+    "bcryptjs": "^3.0.3",
+    "jose": "^6.2.2",
     "next": "16.2.1",
+    "pg": "^8.20.0",
+    "prisma": "^7.6.0",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "@prisma/config";
+
+export default defineConfig({
+  datasource: {
+    url: process.env.DATABASE_URL,
+  },
+});

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,35 +7,67 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
-// 営業マスタ
-model SalesPerson {
-  salesPersonId Int      @id @default(autoincrement()) @map("sales_person_id")
-  name          String   @db.VarChar(100)
-  email         String   @unique @db.VarChar(255)
-  department    String   @db.VarChar(100)
-  isManager     Boolean  @default(false) @map("is_manager")
-  createdAt     DateTime @default(now()) @map("created_at")
-  updatedAt     DateTime @updatedAt @map("updated_at")
+// ロール定義
+enum Role {
+  sales
+  manager
+  admin
+}
 
-  dailyReports     DailyReport[]
-  managerComments  ManagerComment[]
+// 日報ステータス
+enum ReportStatus {
+  draft
+  submitted
+}
 
-  @@map("sales_persons")
+// コメント対象セクション
+enum CommentTargetType {
+  problem
+  plan
+}
+
+// 部署マスタ
+model Department {
+  id        Int      @id @default(autoincrement())
+  name      String   @db.VarChar(100)
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  users User[]
+
+  @@map("departments")
+}
+
+// ユーザーマスタ
+model User {
+  id           Int      @id @default(autoincrement())
+  name         String   @db.VarChar(100)
+  email        String   @unique @db.VarChar(255)
+  passwordHash String   @map("password_hash") @db.VarChar(255)
+  role         Role
+  departmentId Int?     @map("department_id")
+  createdAt    DateTime @default(now()) @map("created_at")
+  updatedAt    DateTime @updatedAt @map("updated_at")
+
+  department   Department?  @relation(fields: [departmentId], references: [id], onDelete: SetNull)
+  dailyReports DailyReport[]
+  comments     Comment[]
+
+  @@map("users")
 }
 
 // 顧客マスタ
 model Customer {
-  customerId    Int      @id @default(autoincrement()) @map("customer_id")
-  companyName   String   @db.VarChar(200) @map("company_name")
-  contactPerson String?  @db.VarChar(100) @map("contact_person")
-  phone         String?  @db.VarChar(20)
-  email         String?  @db.VarChar(255)
-  address       String?  @db.VarChar(500)
-  createdAt     DateTime @default(now()) @map("created_at")
-  updatedAt     DateTime @updatedAt @map("updated_at")
+  id          Int      @id @default(autoincrement())
+  name        String   @db.VarChar(100)
+  companyName String   @map("company_name") @db.VarChar(200)
+  phone       String?  @db.VarChar(20)
+  email       String?  @db.VarChar(255)
+  address     String?  @db.VarChar(500)
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
 
   visitRecords VisitRecord[]
 
@@ -44,47 +76,50 @@ model Customer {
 
 // 日報
 model DailyReport {
-  reportId      Int      @id @default(autoincrement()) @map("report_id")
-  salesPersonId Int      @map("sales_person_id")
-  reportDate    DateTime @db.Date @map("report_date")
-  problem       String?  @db.Text
-  plan          String?  @db.Text
-  createdAt     DateTime @default(now()) @map("created_at")
-  updatedAt     DateTime @updatedAt @map("updated_at")
+  id          Int          @id @default(autoincrement())
+  userId      Int          @map("user_id")
+  reportDate  DateTime     @db.Date @map("report_date")
+  status      ReportStatus @default(draft)
+  submittedAt DateTime?    @map("submitted_at")
+  problem     String?      @db.Text
+  plan        String?      @db.Text
+  createdAt   DateTime     @default(now()) @map("created_at")
+  updatedAt   DateTime     @updatedAt @map("updated_at")
 
-  salesPerson     SalesPerson      @relation(fields: [salesPersonId], references: [salesPersonId])
-  visitRecords    VisitRecord[]
-  managerComments ManagerComment[]
+  user         User          @relation(fields: [userId], references: [id])
+  visitRecords VisitRecord[]
+  comments     Comment[]
 
-  @@unique([salesPersonId, reportDate])
+  @@unique([userId, reportDate])
   @@map("daily_reports")
 }
 
 // 訪問記録
 model VisitRecord {
-  visitId      Int      @id @default(autoincrement()) @map("visit_id")
-  reportId     Int      @map("report_id")
-  customerId   Int      @map("customer_id")
-  visitContent String   @db.Text @map("visit_content")
-  visitTime    String?  @db.VarChar(5) @map("visit_time") // HH:MM
-  createdAt    DateTime @default(now()) @map("created_at")
+  id         Int      @id @default(autoincrement())
+  reportId   Int      @map("report_id")
+  customerId Int      @map("customer_id")
+  content    String   @db.Text
+  visitedAt  String?  @db.VarChar(5) @map("visited_at") // HH:MM
+  createdAt  DateTime @default(now()) @map("created_at")
 
-  dailyReport DailyReport @relation(fields: [reportId], references: [reportId], onDelete: Cascade)
-  customer    Customer    @relation(fields: [customerId], references: [customerId])
+  dailyReport DailyReport @relation(fields: [reportId], references: [id], onDelete: Cascade)
+  customer    Customer    @relation(fields: [customerId], references: [id])
 
   @@map("visit_records")
 }
 
-// 上長コメント
-model ManagerComment {
-  commentId   Int      @id @default(autoincrement()) @map("comment_id")
-  reportId    Int      @map("report_id")
-  managerId   Int      @map("manager_id")
-  comment     String   @db.Text
-  createdAt   DateTime @default(now()) @map("created_at")
+// コメント（problem / plan セクションへの上長コメント）
+model Comment {
+  id         Int               @id @default(autoincrement())
+  reportId   Int               @map("report_id")
+  userId     Int               @map("user_id")
+  targetType CommentTargetType @map("target_type")
+  content    String            @db.Text
+  createdAt  DateTime          @default(now()) @map("created_at")
 
-  dailyReport DailyReport @relation(fields: [reportId], references: [reportId], onDelete: Cascade)
-  manager     SalesPerson @relation(fields: [managerId], references: [salesPersonId])
+  dailyReport DailyReport @relation(fields: [reportId], references: [id], onDelete: Cascade)
+  user        User        @relation(fields: [userId], references: [id])
 
-  @@map("manager_comments")
+  @@map("comments")
 }

--- a/src/app/api/reports/[id]/route.ts
+++ b/src/app/api/reports/[id]/route.ts
@@ -1,0 +1,282 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  requireAuth,
+  forbiddenResponse,
+} from "@/src/lib/middleware/auth";
+import { updateReportSchema } from "@/src/lib/schemas/report";
+import { ZodError } from "zod";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function notFoundResponse(): NextResponse {
+  return NextResponse.json(
+    { error: { code: "NOT_FOUND", message: "日報が見つかりません" } },
+    { status: 404 },
+  );
+}
+
+function parseReportId(idParam: string): number | null {
+  const id = parseInt(idParam, 10);
+  return Number.isNaN(id) || id <= 0 ? null : id;
+}
+
+/** 日報を Prisma で取得する（user / visitRecords / comments を含む） */
+async function fetchReport(id: number) {
+  const { prisma } = await import("@/src/lib/prisma");
+  return prisma.dailyReport.findUnique({
+    where: { id },
+    include: {
+      user: {
+        select: {
+          id: true,
+          name: true,
+          departmentId: true,
+          department: { select: { id: true, name: true } },
+        },
+      },
+      visitRecords: {
+        include: {
+          customer: { select: { id: true, name: true, companyName: true } },
+        },
+        orderBy: { id: "asc" },
+      },
+      comments: {
+        include: {
+          user: { select: { id: true, name: true } },
+        },
+        orderBy: { id: "asc" },
+      },
+    },
+  });
+}
+
+type ReportWithRelations = NonNullable<Awaited<ReturnType<typeof fetchReport>>>;
+
+/** レスポンス用にシリアライズする */
+function serializeReport(report: ReportWithRelations) {
+  return {
+    id: report.id,
+    report_date: report.reportDate.toISOString().slice(0, 10),
+    status: report.status,
+    submitted_at: report.submittedAt?.toISOString() ?? null,
+    user: {
+      id: report.user.id,
+      name: report.user.name,
+      department: report.user.department
+        ? { id: report.user.department.id, name: report.user.department.name }
+        : null,
+    },
+    visit_records: report.visitRecords.map((vr) => ({
+      id: vr.id,
+      customer: {
+        id: vr.customer.id,
+        name: vr.customer.name,
+        company_name: vr.customer.companyName,
+      },
+      content: vr.content,
+      visited_at: vr.visitedAt ?? null,
+    })),
+    problem: report.problem ?? null,
+    plan: report.plan ?? null,
+    comments: report.comments.map((c) => ({
+      id: c.id,
+      target_type: c.targetType,
+      content: c.content,
+      user: { id: c.user.id, name: c.user.name },
+      created_at: c.createdAt.toISOString(),
+    })),
+    created_at: report.createdAt.toISOString(),
+    updated_at: report.updatedAt.toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/reports/:id
+// ---------------------------------------------------------------------------
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const authResult = await requireAuth(req);
+  if (authResult.error) return authResult.error;
+  const { user } = authResult;
+
+  const { id: idParam } = await params;
+  const reportId = parseReportId(idParam);
+  if (reportId === null) return notFoundResponse();
+
+  const report = await fetchReport(reportId);
+  if (!report) return notFoundResponse();
+
+  // アクセス制御
+  if (user.role === "sales") {
+    if (report.userId !== user.id) return forbiddenResponse();
+  } else if (user.role === "manager") {
+    // 同一部署チェック
+    if (
+      report.user.departmentId === null ||
+      user.departmentId === null ||
+      report.user.departmentId !== user.departmentId
+    ) {
+      return forbiddenResponse();
+    }
+  }
+  // admin は全日報アクセス可
+
+  return NextResponse.json({ data: serializeReport(report) });
+}
+
+// ---------------------------------------------------------------------------
+// PUT /api/reports/:id
+// ---------------------------------------------------------------------------
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const authResult = await requireAuth(req);
+  if (authResult.error) return authResult.error;
+  const { user } = authResult;
+
+  // sales 本人のみ（manager / admin も不可）
+  if (user.role !== "sales") {
+    return forbiddenResponse();
+  }
+
+  const { id: idParam } = await params;
+  const reportId = parseReportId(idParam);
+  if (reportId === null) return notFoundResponse();
+
+  const { prisma } = await import("@/src/lib/prisma");
+
+  // 日報の存在と所有者チェック
+  const existing = await prisma.dailyReport.findUnique({
+    where: { id: reportId },
+    select: { id: true, userId: true, status: true },
+  });
+  if (!existing) return notFoundResponse();
+
+  if (existing.userId !== user.id) return forbiddenResponse();
+
+  if (existing.status === "submitted") {
+    return NextResponse.json(
+      {
+        error: {
+          code: "REPORT_ALREADY_SUBMITTED",
+          message: "提出済みの日報は編集できません",
+        },
+      },
+      { status: 422 },
+    );
+  }
+
+  // リクエストボディのパース
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "リクエストボディが不正です" } },
+      { status: 400 },
+    );
+  }
+
+  // Zod バリデーション
+  let input;
+  try {
+    input = updateReportSchema.parse(body);
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "入力値が不正です",
+            details: err.issues.map((e) => ({
+              field: e.path.join("."),
+              message: e.message,
+            })),
+          },
+        },
+        { status: 400 },
+      );
+    }
+    throw err;
+  }
+
+  // 顧客IDの存在チェック
+  const customerIds = [
+    ...new Set(input.visit_records.map((r) => r.customer_id)),
+  ];
+  const existingCustomers = await prisma.customer.findMany({
+    where: { id: { in: customerIds } },
+    select: { id: true },
+  });
+  const existingCustomerIds = new Set(existingCustomers.map((c) => c.id));
+  const invalidCustomerIds = customerIds.filter(
+    (id) => !existingCustomerIds.has(id),
+  );
+  if (invalidCustomerIds.length > 0) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: `存在しない顧客IDが含まれています: ${invalidCustomerIds.join(", ")}`,
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const reportDate = new Date(input.report_date);
+
+  // トランザクション: 訪問記録を全件削除→再挿入
+  const updated = await prisma.$transaction(async (tx) => {
+    // 訪問記録を全件削除
+    await tx.visitRecord.deleteMany({ where: { reportId } });
+
+    // 日報本体と訪問記録を更新・再挿入
+    return tx.dailyReport.update({
+      where: { id: reportId },
+      data: {
+        reportDate,
+        problem: input.problem ?? null,
+        plan: input.plan ?? null,
+        visitRecords: {
+          create: input.visit_records.map((r) => ({
+            customerId: r.customer_id,
+            content: r.content,
+            visitedAt: r.visited_at ?? null,
+          })),
+        },
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            departmentId: true,
+            department: { select: { id: true, name: true } },
+          },
+        },
+        visitRecords: {
+          include: {
+            customer: { select: { id: true, name: true, companyName: true } },
+          },
+          orderBy: { id: "asc" },
+        },
+        comments: {
+          include: {
+            user: { select: { id: true, name: true } },
+          },
+          orderBy: { id: "asc" },
+        },
+      },
+    });
+  });
+
+  return NextResponse.json({ data: serializeReport(updated) });
+}

--- a/src/app/api/reports/[id]/submit/route.ts
+++ b/src/app/api/reports/[id]/submit/route.ts
@@ -1,0 +1,154 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth, forbiddenResponse } from "@/src/lib/middleware/auth";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function notFoundResponse(): NextResponse {
+  return NextResponse.json(
+    { error: { code: "NOT_FOUND", message: "日報が見つかりません" } },
+    { status: 404 },
+  );
+}
+
+function parseReportId(idParam: string): number | null {
+  const id = parseInt(idParam, 10);
+  return Number.isNaN(id) || id <= 0 ? null : id;
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/reports/:id/submit
+// ---------------------------------------------------------------------------
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const authResult = await requireAuth(req);
+  if (authResult.error) return authResult.error;
+  const { user } = authResult;
+
+  // sales 本人のみ（manager / admin も不可）
+  if (user.role !== "sales") {
+    return forbiddenResponse();
+  }
+
+  const { id: idParam } = await params;
+  const reportId = parseReportId(idParam);
+  if (reportId === null) return notFoundResponse();
+
+  const { prisma } = await import("@/src/lib/prisma");
+
+  // 日報の存在・所有者・訪問記録件数をまとめて取得
+  const report = await prisma.dailyReport.findUnique({
+    where: { id: reportId },
+    select: {
+      id: true,
+      userId: true,
+      status: true,
+      _count: { select: { visitRecords: true } },
+    },
+  });
+
+  if (!report) return notFoundResponse();
+
+  // 所有者チェック
+  if (report.userId !== user.id) return forbiddenResponse();
+
+  // 提出済みチェック
+  if (report.status === "submitted") {
+    return NextResponse.json(
+      {
+        error: {
+          code: "REPORT_ALREADY_SUBMITTED",
+          message: "既に提出済みの日報です",
+        },
+      },
+      { status: 422 },
+    );
+  }
+
+  // 訪問記録が0件の場合は提出不可
+  if (report._count.visitRecords === 0) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VISIT_RECORD_REQUIRED",
+          message: "提出には訪問記録が1件以上必要です",
+        },
+      },
+      { status: 422 },
+    );
+  }
+
+  // status を submitted に更新
+  const updated = await prisma.dailyReport.update({
+    where: { id: reportId },
+    data: {
+      status: "submitted",
+      submittedAt: new Date(),
+    },
+    include: {
+      user: {
+        select: {
+          id: true,
+          name: true,
+          department: { select: { id: true, name: true } },
+        },
+      },
+      visitRecords: {
+        include: {
+          customer: { select: { id: true, name: true, companyName: true } },
+        },
+        orderBy: { id: "asc" },
+      },
+      comments: {
+        include: {
+          user: { select: { id: true, name: true } },
+        },
+        orderBy: { id: "asc" },
+      },
+    },
+  });
+
+  return NextResponse.json({
+    data: {
+      id: updated.id,
+      report_date: updated.reportDate.toISOString().slice(0, 10),
+      status: updated.status,
+      submitted_at: updated.submittedAt?.toISOString() ?? null,
+      user: {
+        id: updated.user.id,
+        name: updated.user.name,
+        department: updated.user.department
+          ? {
+              id: updated.user.department.id,
+              name: updated.user.department.name,
+            }
+          : null,
+      },
+      visit_records: updated.visitRecords.map((vr) => ({
+        id: vr.id,
+        customer: {
+          id: vr.customer.id,
+          name: vr.customer.name,
+          company_name: vr.customer.companyName,
+        },
+        content: vr.content,
+        visited_at: vr.visitedAt ?? null,
+      })),
+      problem: updated.problem ?? null,
+      plan: updated.plan ?? null,
+      comments: updated.comments.map((c) => ({
+        id: c.id,
+        target_type: c.targetType,
+        content: c.content,
+        user: { id: c.user.id, name: c.user.name },
+        created_at: c.createdAt.toISOString(),
+      })),
+      created_at: updated.createdAt.toISOString(),
+      updated_at: updated.updatedAt.toISOString(),
+    },
+  });
+}

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth, hasPermission, forbiddenResponse } from "@/src/lib/middleware/auth";
+import { createReportSchema } from "@/src/lib/schemas/report";
+import { ZodError } from "zod";
+
+export async function POST(req: NextRequest) {
+  // 認証チェック
+  const authResult = await requireAuth(req);
+  if (authResult.error) return authResult.error;
+  const { user } = authResult;
+
+  // ロールチェック（sales のみ）
+  if (!hasPermission(user, "create_report")) {
+    return forbiddenResponse();
+  }
+
+  // リクエストボディのパース
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "リクエストボディが不正です" } },
+      { status: 400 },
+    );
+  }
+
+  // Zod バリデーション
+  let input;
+  try {
+    input = createReportSchema.parse(body);
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "入力値が不正です",
+            details: err.issues.map((e) => ({
+              field: e.path.join("."),
+              message: e.message,
+            })),
+          },
+        },
+        { status: 400 },
+      );
+    }
+    throw err;
+  }
+
+  const { prisma } = await import("@/src/lib/prisma");
+
+  // 顧客IDの存在チェック
+  const customerIds = [...new Set(input.visit_records.map((r) => r.customer_id))];
+  const existingCustomers = await prisma.customer.findMany({
+    where: { id: { in: customerIds } },
+    select: { id: true },
+  });
+  const existingCustomerIds = new Set(existingCustomers.map((c) => c.id));
+  const invalidCustomerIds = customerIds.filter((id) => !existingCustomerIds.has(id));
+  if (invalidCustomerIds.length > 0) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: `存在しない顧客IDが含まれています: ${invalidCustomerIds.join(", ")}`,
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const reportDate = new Date(input.report_date);
+
+  // トランザクションで日報と訪問記録を挿入
+  // SELECT FOR UPDATE で同日重複のレースコンディションを防ぐ
+  let report;
+  try {
+    report = await prisma.$transaction(async (tx) => {
+      // SELECT FOR UPDATE で同日の日報をロック
+      const existing = await tx.$queryRaw<{ id: number }[]>`
+        SELECT id FROM daily_reports
+        WHERE user_id = ${user.id}
+          AND report_date = ${reportDate}::date
+        FOR UPDATE
+      `;
+      if (existing.length > 0) {
+        throw new DuplicateReportError();
+      }
+
+      const created = await tx.dailyReport.create({
+        data: {
+          userId: user.id,
+          reportDate,
+          status: "draft",
+          problem: input.problem ?? null,
+          plan: input.plan ?? null,
+          visitRecords: {
+            create: input.visit_records.map((r) => ({
+              customerId: r.customer_id,
+              content: r.content,
+              visitedAt: r.visited_at ?? null,
+            })),
+          },
+        },
+        include: {
+          user: { select: { id: true, name: true } },
+          visitRecords: {
+            include: {
+              customer: { select: { id: true, name: true, companyName: true } },
+            },
+          },
+          comments: true,
+        },
+      });
+
+      return created;
+    });
+  } catch (err) {
+    if (err instanceof DuplicateReportError) {
+      return NextResponse.json(
+        { error: { code: "REPORT_ALREADY_EXISTS", message: "同日の日報が既に存在します" } },
+        { status: 422 },
+      );
+    }
+    throw err;
+  }
+
+  return NextResponse.json(
+    {
+      data: {
+        id: report.id,
+        report_date: report.reportDate.toISOString().slice(0, 10),
+        status: report.status,
+        submitted_at: report.submittedAt?.toISOString() ?? null,
+        user: report.user,
+        visit_records: report.visitRecords.map((vr) => ({
+          id: vr.id,
+          customer: {
+            id: vr.customer.id,
+            name: vr.customer.name,
+            company_name: vr.customer.companyName,
+          },
+          content: vr.content,
+          visited_at: vr.visitedAt ?? null,
+        })),
+        problem: report.problem ?? null,
+        plan: report.plan ?? null,
+        comments: [],
+        created_at: report.createdAt.toISOString(),
+        updated_at: report.updatedAt.toISOString(),
+      },
+    },
+    { status: 201 },
+  );
+}
+
+class DuplicateReportError extends Error {
+  constructor() {
+    super("REPORT_ALREADY_EXISTS");
+  }
+}

--- a/src/lib/auth/jwt.ts
+++ b/src/lib/auth/jwt.ts
@@ -1,0 +1,46 @@
+import { SignJWT, jwtVerify } from "jose";
+
+function getSecret(): Uint8Array {
+  const key = process.env.JWT_SECRET ?? "development-getSecret()-key";
+  return Buffer.from(key, "utf-8");
+}
+
+function getExpiresIn(): string {
+  return process.env.JWT_EXPIRES_IN ?? "24h";
+}
+
+export async function generateToken(userId: number): Promise<string> {
+  return new SignJWT({ userId })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime(getExpiresIn())
+    .sign(getSecret());
+}
+
+export async function verifyToken(token: string): Promise<{ userId: number }> {
+  const { payload } = await jwtVerify(token, getSecret());
+  if (typeof payload.userId !== "number") {
+    throw new Error("Invalid token payload");
+  }
+  return { userId: payload.userId };
+}
+
+export async function getTokenExpiresAt(): Promise<Date> {
+  const expiresIn = getExpiresIn();
+  const ms = parseExpiresIn(expiresIn);
+  return new Date(Date.now() + ms);
+}
+
+function parseExpiresIn(expiresIn: string): number {
+  const match = expiresIn.match(/^(\d+)(h|m|s|d)$/);
+  if (!match) return 24 * 60 * 60 * 1000;
+  const value = parseInt(match[1], 10);
+  const unit = match[2];
+  const multipliers: Record<string, number> = {
+    s: 1000,
+    m: 60 * 1000,
+    h: 60 * 60 * 1000,
+    d: 24 * 60 * 60 * 1000,
+  };
+  return value * multipliers[unit];
+}

--- a/src/lib/auth/password.ts
+++ b/src/lib/auth/password.ts
@@ -1,0 +1,14 @@
+import bcrypt from "bcryptjs";
+
+const SALT_ROUNDS = 10;
+
+export async function hashPassword(plain: string): Promise<string> {
+  return bcrypt.hash(plain, SALT_ROUNDS);
+}
+
+export async function verifyPassword(
+  plain: string,
+  hash: string,
+): Promise<boolean> {
+  return bcrypt.compare(plain, hash);
+}

--- a/src/lib/auth/token-blacklist.ts
+++ b/src/lib/auth/token-blacklist.ts
@@ -1,0 +1,13 @@
+/**
+ * インメモリのトークンブラックリスト。
+ * 本番環境では Redis や DB に移行すること。
+ */
+const blacklist = new Set<string>();
+
+export function addToBlacklist(token: string): void {
+  blacklist.add(token);
+}
+
+export function isBlacklisted(token: string): boolean {
+  return blacklist.has(token);
+}

--- a/src/lib/middleware/auth.ts
+++ b/src/lib/middleware/auth.ts
@@ -1,0 +1,202 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyToken } from "@/src/lib/auth/jwt";
+import { isBlacklisted } from "@/src/lib/auth/token-blacklist";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type Role = "sales" | "manager" | "admin";
+
+export type Action =
+  | "create_report"
+  | "post_comment"
+  | "manage_customers"
+  | "manage_users";
+
+/**
+ * 認証済みユーザーの型。
+ * Prisma の User モデルから機密情報（passwordHash）を除いたもの。
+ */
+export interface AuthUser {
+  id: number;
+  name: string;
+  email: string;
+  role: Role;
+  departmentId: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Permission matrix (UT-006 対応)
+// ---------------------------------------------------------------------------
+
+const PERMISSION_MAP: Record<Action, Role[]> = {
+  create_report: ["sales"],
+  post_comment: ["manager", "admin"],
+  manage_customers: ["manager", "admin"],
+  manage_users: ["admin"],
+};
+
+/**
+ * ユーザーが指定したアクションを実行する権限を持つか確認する。
+ *
+ * UT-006 の 8 ケース全対応:
+ *   1. sales    + create_report    → true
+ *   2. manager  + create_report    → false
+ *   3. manager  + post_comment     → true
+ *   4. sales    + post_comment     → false
+ *   5. admin    + manage_users     → true
+ *   6. manager  + manage_users     → false
+ *   7. sales    + manage_customers → false
+ *   8. manager  + manage_customers → true
+ */
+export function hasPermission(user: AuthUser, action: Action): boolean {
+  return PERMISSION_MAP[action].includes(user.role);
+}
+
+// ---------------------------------------------------------------------------
+// AuthError
+// ---------------------------------------------------------------------------
+
+export class AuthError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AuthError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Token extraction helper
+// ---------------------------------------------------------------------------
+
+function extractBearerToken(req: NextRequest): string | null {
+  const authorization = req.headers.get("authorization");
+  if (!authorization || !authorization.startsWith("Bearer ")) {
+    return null;
+  }
+  const token = authorization.slice(7).trim();
+  return token.length > 0 ? token : null;
+}
+
+// ---------------------------------------------------------------------------
+// getAuthUser
+// ---------------------------------------------------------------------------
+
+/**
+ * リクエストの Authorization ヘッダーからトークンを検証し、
+ * 認証済みユーザーを返す。
+ *
+ * Prisma クライアントを動的にインポートすることで、
+ * テスト時の不要な初期化を回避する。
+ *
+ * 失敗した場合は AuthError をスローする。呼び出し側で catch して 401 を返すこと。
+ */
+export async function getAuthUser(req: NextRequest): Promise<AuthUser> {
+  const token = extractBearerToken(req);
+  if (!token) {
+    throw new AuthError("UNAUTHORIZED", "認証トークンが指定されていません");
+  }
+
+  if (isBlacklisted(token)) {
+    throw new AuthError("UNAUTHORIZED", "無効なトークンです");
+  }
+
+  let userId: number;
+  try {
+    const payload = await verifyToken(token);
+    userId = payload.userId;
+  } catch {
+    throw new AuthError("UNAUTHORIZED", "トークンが無効または期限切れです");
+  }
+
+  // Prisma を動的インポートして、モジュールロード時の初期化エラーを回避する
+  const { prisma } = await import("@/src/lib/prisma");
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      role: true,
+      departmentId: true,
+    },
+  });
+
+  if (!user) {
+    throw new AuthError("UNAUTHORIZED", "ユーザーが存在しません");
+  }
+
+  return {
+    id: user.id,
+    name: user.name,
+    email: user.email,
+    role: user.role as Role,
+    departmentId: user.departmentId,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// requireAuth helper — for use inside route handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * ルートハンドラー内でユーザーを取得し、失敗時に 401 レスポンスを返す。
+ *
+ * @example
+ * ```ts
+ * export async function GET(req: NextRequest) {
+ *   const result = await requireAuth(req);
+ *   if (result.error) return result.error;
+ *   const { user } = result;
+ *   // ... use user
+ * }
+ * ```
+ */
+export async function requireAuth(
+  req: NextRequest,
+): Promise<
+  { user: AuthUser; error: null } | { user: null; error: NextResponse }
+> {
+  try {
+    const user = await getAuthUser(req);
+    return { user, error: null };
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return {
+        user: null,
+        error: NextResponse.json(
+          { error: { code: err.code, message: err.message } },
+          { status: 401 },
+        ),
+      };
+    }
+    return {
+      user: null,
+      error: NextResponse.json(
+        {
+          error: {
+            code: "INTERNAL_SERVER_ERROR",
+            message: "サーバーエラーが発生しました",
+          },
+        },
+        { status: 500 },
+      ),
+    };
+  }
+}
+
+/**
+ * ロール違反時に 403 レスポンスを返すヘルパー。
+ */
+export function forbiddenResponse(
+  message = "操作する権限がありません",
+): NextResponse {
+  return NextResponse.json(
+    { error: { code: "FORBIDDEN", message } },
+    { status: 403 },
+  );
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,16 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
+
+function createPrismaClient(): PrismaClient {
+  const connectionString = process.env.DATABASE_URL ?? "";
+  const adapter = new PrismaPg({ connectionString });
+  return new PrismaClient({ adapter });
+}
+
+export const prisma = globalForPrisma.prisma ?? createPrismaClient();
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}

--- a/src/lib/schemas/report.ts
+++ b/src/lib/schemas/report.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+// HH:MM 形式（00:00〜23:59）の時刻バリデーション
+const visitedAtSchema = z
+  .string()
+  .regex(/^\d{2}:\d{2}$/, "visited_at は HH:MM 形式で指定してください")
+  .refine((val) => {
+    const [hh, mm] = val.split(":").map(Number);
+    return hh >= 0 && hh <= 23 && mm >= 0 && mm <= 59;
+  }, "visited_at の時刻が不正です（00:00〜23:59）")
+  .optional();
+
+export const visitRecordSchema = z.object({
+  customer_id: z.number("customer_id は必須です").int().positive(),
+  content: z
+    .string("content は必須です")
+    .min(1, "content は1文字以上必要です")
+    .max(1000, "content は1000文字以内で入力してください"),
+  visited_at: visitedAtSchema,
+});
+
+export const createReportSchema = z.object({
+  report_date: z
+    .string("report_date は必須です")
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "report_date は YYYY-MM-DD 形式で指定してください")
+    .refine((val) => {
+      const date = new Date(val);
+      return !isNaN(date.getTime()) && val === date.toISOString().slice(0, 10);
+    }, "report_date が不正な日付です"),
+  visit_records: z
+    .array(visitRecordSchema)
+    .min(1, "visit_records は1件以上必要です"),
+  problem: z
+    .string()
+    .max(2000, "problem は2000文字以内で入力してください")
+    .optional(),
+  plan: z
+    .string()
+    .max(2000, "plan は2000文字以内で入力してください")
+    .optional(),
+});
+
+// PUT /api/reports/:id — update (same shape as create)
+export const updateReportSchema = createReportSchema;
+
+export type CreateReportInput = z.infer<typeof createReportSchema>;
+export type UpdateReportInput = z.infer<typeof updateReportSchema>;
+export type VisitRecordInput = z.infer<typeof visitRecordSchema>;

--- a/src/test/unit/middleware/auth.test.ts
+++ b/src/test/unit/middleware/auth.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { hasPermission } from "@/src/lib/middleware/auth";
+import type { AuthUser, Action } from "@/src/lib/middleware/auth";
+
+function makeUser(role: AuthUser["role"]): AuthUser {
+  return {
+    id: 1,
+    name: "テストユーザー",
+    email: "test@example.com",
+    role,
+    departmentId: 1,
+  };
+}
+
+describe("UT-006: hasPermission 権限チェック関数", () => {
+  // ケース1: sales は create_report を実行できる
+  it("sales は create_report を実行できる", () => {
+    const user = makeUser("sales");
+    const action: Action = "create_report";
+    expect(hasPermission(user, action)).toBe(true);
+  });
+
+  // ケース2: manager は create_report を実行できない
+  it("manager は create_report を実行できない", () => {
+    const user = makeUser("manager");
+    const action: Action = "create_report";
+    expect(hasPermission(user, action)).toBe(false);
+  });
+
+  // ケース3: manager は post_comment を実行できる
+  it("manager は post_comment を実行できる", () => {
+    const user = makeUser("manager");
+    const action: Action = "post_comment";
+    expect(hasPermission(user, action)).toBe(true);
+  });
+
+  // ケース4: sales は post_comment を実行できない
+  it("sales は post_comment を実行できない", () => {
+    const user = makeUser("sales");
+    const action: Action = "post_comment";
+    expect(hasPermission(user, action)).toBe(false);
+  });
+
+  // ケース5: admin は manage_users を実行できる
+  it("admin は manage_users を実行できる", () => {
+    const user = makeUser("admin");
+    const action: Action = "manage_users";
+    expect(hasPermission(user, action)).toBe(true);
+  });
+
+  // ケース6: manager は manage_users を実行できない
+  it("manager は manage_users を実行できない", () => {
+    const user = makeUser("manager");
+    const action: Action = "manage_users";
+    expect(hasPermission(user, action)).toBe(false);
+  });
+
+  // ケース7: sales は manage_customers を実行できない
+  it("sales は manage_customers を実行できない", () => {
+    const user = makeUser("sales");
+    const action: Action = "manage_customers";
+    expect(hasPermission(user, action)).toBe(false);
+  });
+
+  // ケース8: manager は manage_customers を実行できる
+  it("manager は manage_customers を実行できる", () => {
+    const user = makeUser("manager");
+    const action: Action = "manage_customers";
+    expect(hasPermission(user, action)).toBe(true);
+  });
+
+  // admin は全アクションを実行できることを確認（追加確認）
+  it("admin は post_comment を実行できる", () => {
+    const user = makeUser("admin");
+    expect(hasPermission(user, "post_comment")).toBe(true);
+  });
+
+  it("admin は manage_customers を実行できる", () => {
+    const user = makeUser("admin");
+    expect(hasPermission(user, "manage_customers")).toBe(true);
+  });
+});

--- a/src/test/unit/schemas/report.test.ts
+++ b/src/test/unit/schemas/report.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { visitRecordSchema, createReportSchema } from "@/src/lib/schemas/report";
+
+// UT-007: 訪問記録バリデーション
+describe("UT-007: 訪問記録バリデーション", () => {
+  // ケース1: 1件・全項目あり → バリデーションOK
+  it("1件・全項目ありの場合はバリデーションOK", () => {
+    const result = visitRecordSchema.safeParse({
+      customer_id: 10,
+      content: "新製品の提案を実施。先方の反応は良好。",
+      visited_at: "10:00",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  // ケース2: 空配列 → エラー（1件以上必要）
+  it("visit_records が空配列の場合はエラー", () => {
+    const result = createReportSchema.safeParse({
+      report_date: "2026-04-01",
+      visit_records: [],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((e) => e.path.includes("visit_records"))).toBe(true);
+    }
+  });
+
+  // ケース3: customer_id が null → エラー
+  it("customer_id が null の場合はエラー", () => {
+    const result = visitRecordSchema.safeParse({
+      customer_id: null,
+      content: "内容",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // ケース4: content が空文字 → エラー
+  it("content が空文字の場合はエラー", () => {
+    const result = visitRecordSchema.safeParse({
+      customer_id: 10,
+      content: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // ケース5: content が1000文字 → バリデーションOK
+  it("content が1000文字の場合はバリデーションOK", () => {
+    const result = visitRecordSchema.safeParse({
+      customer_id: 10,
+      content: "a".repeat(1000),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  // ケース6: content が1001文字 → エラー
+  it("content が1001文字の場合はエラー", () => {
+    const result = visitRecordSchema.safeParse({
+      customer_id: 10,
+      content: "a".repeat(1001),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // ケース7: visited_at が `25:00` → エラー（時刻形式不正）
+  it("visited_at が 25:00 の場合はエラー", () => {
+    const result = visitRecordSchema.safeParse({
+      customer_id: 10,
+      content: "内容",
+      visited_at: "25:00",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // ケース8: visited_at が null → バリデーションOK（任意項目）
+  it("visited_at が null の場合はバリデーションOK", () => {
+    const result = visitRecordSchema.safeParse({
+      customer_id: 10,
+      content: "内容",
+      visited_at: undefined,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// UT-008: 日付フォーマット変換
+describe("UT-008: 日付フォーマット変換（report_date バリデーション）", () => {
+  // ケース1: 正常な日付
+  it("2026-04-01 は正常にパースできる", () => {
+    const result = createReportSchema.safeParse({
+      report_date: "2026-04-01",
+      visit_records: [{ customer_id: 1, content: "内容" }],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  // ケース2: スラッシュ区切り → エラー
+  it("2026/04/01 はエラー（形式不正）", () => {
+    const result = createReportSchema.safeParse({
+      report_date: "2026/04/01",
+      visit_records: [{ customer_id: 1, content: "内容" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // ケース3: 月が不正 → エラー
+  it("2026-13-01 はエラー（月が不正）", () => {
+    const result = createReportSchema.safeParse({
+      report_date: "2026-13-01",
+      visit_records: [{ customer_id: 1, content: "内容" }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  // ケース4: 存在しない日付 → エラー
+  it("2026-04-31 はエラー（存在しない日付）", () => {
+    const result = createReportSchema.safeParse({
+      report_date: "2026-04-31",
+      visit_records: [{ customer_id: 1, content: "内容" }],
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "issue-003"]
 }


### PR DESCRIPTION
## Summary

- `GET /api/reports/:id`: ロールに応じたアクセス制御付きで日報詳細を返す（sales=自分のみ、manager=同一部署、admin=全件）
- `PUT /api/reports/:id`: sales 本人かつ draft のみ更新可。訪問記録は全件削除→再挿入をトランザクションで実行
- `POST /api/reports/:id/submit`: sales 本人かつ draft のみ提出可。訪問記録0件は `VISIT_RECORD_REQUIRED` (422)

## Changes

- Prisma スキーマを正しいモデル構成（User / DailyReport / VisitRecord / Comment / Customer / Department）に更新
- Prisma v7 対応: `prisma.config.ts` を追加し、`schema.prisma` から `datasource.url` を削除
- `src/lib/prisma.ts` を `PrismaPg` アダプター経由に更新
- `updateReportSchema` を `src/lib/schemas/report.ts` に追加

## Test plan

- [ ] `GET /api/reports/:id` — 未認証 → 401
- [ ] `GET /api/reports/:id` — sales が他人の日報 → 403
- [ ] `GET /api/reports/:id` — manager が別部署の日報 → 403
- [ ] `GET /api/reports/:id` — admin が任意の日報 → 200
- [ ] `PUT /api/reports/:id` — manager/admin → 403
- [ ] `PUT /api/reports/:id` — 提出済み日報 → 422 REPORT_ALREADY_SUBMITTED
- [ ] `PUT /api/reports/:id` — 有効なリクエスト → 200（訪問記録が差し替えられていること）
- [ ] `POST /api/reports/:id/submit` — 訪問記録0件 → 422 VISIT_RECORD_REQUIRED
- [ ] `POST /api/reports/:id/submit` — 提出済み → 422 REPORT_ALREADY_SUBMITTED
- [ ] `POST /api/reports/:id/submit` — 正常ケース → 200（status=submitted, submitted_at が設定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)