### PR TITLE
feat: Issue #1 Prismaスキーマを仕様書に合わせて再設計する

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "prisma/config";
+
+export default defineConfig({
+  datasource: {
+    url: process.env.DATABASE_URL ?? "postgresql://dummy:dummy@localhost:5432/dummy",
+  },
+});

--- a/prisma/migrations/0001_init/migration.sql
+++ b/prisma/migrations/0001_init/migration.sql
@@ -1,0 +1,115 @@
+Loaded Prisma config from prisma.config.ts.
+
+-- CreateSchema
+CREATE SCHEMA IF NOT EXISTS "public";
+
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('sales', 'manager', 'admin');
+
+-- CreateEnum
+CREATE TYPE "ReportStatus" AS ENUM ('draft', 'submitted');
+
+-- CreateEnum
+CREATE TYPE "CommentTargetType" AS ENUM ('problem', 'plan');
+
+-- CreateTable
+CREATE TABLE "departments" (
+    "id" SERIAL NOT NULL,
+    "name" VARCHAR(100) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "departments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" SERIAL NOT NULL,
+    "name" VARCHAR(100) NOT NULL,
+    "email" VARCHAR(255) NOT NULL,
+    "password_hash" VARCHAR(255) NOT NULL,
+    "role" "Role" NOT NULL,
+    "department_id" INTEGER,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "customers" (
+    "id" SERIAL NOT NULL,
+    "name" VARCHAR(100) NOT NULL,
+    "company_name" VARCHAR(200) NOT NULL,
+    "phone" VARCHAR(20),
+    "email" VARCHAR(255),
+    "address" VARCHAR(500),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "customers_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "daily_reports" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "report_date" DATE NOT NULL,
+    "status" "ReportStatus" NOT NULL DEFAULT 'draft',
+    "submitted_at" TIMESTAMP(3),
+    "problem" TEXT,
+    "plan" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "daily_reports_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "visit_records" (
+    "id" SERIAL NOT NULL,
+    "report_id" INTEGER NOT NULL,
+    "customer_id" INTEGER NOT NULL,
+    "content" TEXT NOT NULL,
+    "visited_at" VARCHAR(5),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "visit_records_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "comments" (
+    "id" SERIAL NOT NULL,
+    "report_id" INTEGER NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "target_type" "CommentTargetType" NOT NULL,
+    "content" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "comments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "daily_reports_user_id_report_date_key" ON "daily_reports"("user_id", "report_date");
+
+-- AddForeignKey
+ALTER TABLE "users" ADD CONSTRAINT "users_department_id_fkey" FOREIGN KEY ("department_id") REFERENCES "departments"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "daily_reports" ADD CONSTRAINT "daily_reports_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "visit_records" ADD CONSTRAINT "visit_records_report_id_fkey" FOREIGN KEY ("report_id") REFERENCES "daily_reports"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "visit_records" ADD CONSTRAINT "visit_records_customer_id_fkey" FOREIGN KEY ("customer_id") REFERENCES "customers"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "comments" ADD CONSTRAINT "comments_report_id_fkey" FOREIGN KEY ("report_id") REFERENCES "daily_reports"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "comments" ADD CONSTRAINT "comments_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,90 +1,113 @@
-// This is your Prisma schema file,
-// learn more about it in the docs: https://pris.ly/d/prisma-schema
-
 generator client {
   provider = "prisma-client-js"
 }
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
-// 営業マスタ
-model SalesPerson {
-  salesPersonId Int      @id @default(autoincrement()) @map("sales_person_id")
-  name          String   @db.VarChar(100)
-  email         String   @unique @db.VarChar(255)
-  department    String   @db.VarChar(100)
-  isManager     Boolean  @default(false) @map("is_manager")
-  createdAt     DateTime @default(now()) @map("created_at")
-  updatedAt     DateTime @updatedAt @map("updated_at")
-
-  dailyReports     DailyReport[]
-  managerComments  ManagerComment[]
-
-  @@map("sales_persons")
+enum Role {
+  sales
+  manager
+  admin
 }
 
-// 顧客マスタ
+enum ReportStatus {
+  draft
+  submitted
+}
+
+enum CommentTargetType {
+  problem
+  plan
+}
+
+model Department {
+  id        Int      @id @default(autoincrement())
+  name      String   @db.VarChar(100)
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  users User[]
+
+  @@map("departments")
+}
+
+model User {
+  id           Int      @id @default(autoincrement())
+  name         String   @db.VarChar(100)
+  email        String   @unique @db.VarChar(255)
+  passwordHash String   @map("password_hash") @db.VarChar(255)
+  role         Role
+  departmentId Int?     @map("department_id")
+  createdAt    DateTime @default(now()) @map("created_at")
+  updatedAt    DateTime @updatedAt @map("updated_at")
+
+  department   Department?   @relation(fields: [departmentId], references: [id], onDelete: SetNull)
+  dailyReports DailyReport[]
+  comments     Comment[]
+
+  @@map("users")
+}
+
 model Customer {
-  customerId    Int      @id @default(autoincrement()) @map("customer_id")
-  companyName   String   @db.VarChar(200) @map("company_name")
-  contactPerson String?  @db.VarChar(100) @map("contact_person")
-  phone         String?  @db.VarChar(20)
-  email         String?  @db.VarChar(255)
-  address       String?  @db.VarChar(500)
-  createdAt     DateTime @default(now()) @map("created_at")
-  updatedAt     DateTime @updatedAt @map("updated_at")
+  id          Int      @id @default(autoincrement())
+  name        String   @db.VarChar(100)
+  companyName String   @map("company_name") @db.VarChar(200)
+  phone       String?  @db.VarChar(20)
+  email       String?  @db.VarChar(255)
+  address     String?  @db.VarChar(500)
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
 
   visitRecords VisitRecord[]
 
   @@map("customers")
 }
 
-// 日報
 model DailyReport {
-  reportId      Int      @id @default(autoincrement()) @map("report_id")
-  salesPersonId Int      @map("sales_person_id")
-  reportDate    DateTime @db.Date @map("report_date")
-  problem       String?  @db.Text
-  plan          String?  @db.Text
-  createdAt     DateTime @default(now()) @map("created_at")
-  updatedAt     DateTime @updatedAt @map("updated_at")
+  id          Int          @id @default(autoincrement())
+  userId      Int          @map("user_id")
+  reportDate  DateTime     @db.Date @map("report_date")
+  status      ReportStatus @default(draft)
+  submittedAt DateTime?    @map("submitted_at")
+  problem     String?      @db.Text
+  plan        String?      @db.Text
+  createdAt   DateTime     @default(now()) @map("created_at")
+  updatedAt   DateTime     @updatedAt @map("updated_at")
 
-  salesPerson     SalesPerson      @relation(fields: [salesPersonId], references: [salesPersonId])
-  visitRecords    VisitRecord[]
-  managerComments ManagerComment[]
+  user         User          @relation(fields: [userId], references: [id])
+  visitRecords VisitRecord[]
+  comments     Comment[]
 
-  @@unique([salesPersonId, reportDate])
+  @@unique([userId, reportDate])
   @@map("daily_reports")
 }
 
-// 訪問記録
 model VisitRecord {
-  visitId      Int      @id @default(autoincrement()) @map("visit_id")
-  reportId     Int      @map("report_id")
-  customerId   Int      @map("customer_id")
-  visitContent String   @db.Text @map("visit_content")
-  visitTime    String?  @db.VarChar(5) @map("visit_time") // HH:MM
-  createdAt    DateTime @default(now()) @map("created_at")
+  id         Int      @id @default(autoincrement())
+  reportId   Int      @map("report_id")
+  customerId Int      @map("customer_id")
+  content    String   @db.Text
+  visitedAt  String?  @db.VarChar(5) @map("visited_at")
+  createdAt  DateTime @default(now()) @map("created_at")
 
-  dailyReport DailyReport @relation(fields: [reportId], references: [reportId], onDelete: Cascade)
-  customer    Customer    @relation(fields: [customerId], references: [customerId])
+  dailyReport DailyReport @relation(fields: [reportId], references: [id], onDelete: Cascade)
+  customer    Customer    @relation(fields: [customerId], references: [id])
 
   @@map("visit_records")
 }
 
-// 上長コメント
-model ManagerComment {
-  commentId   Int      @id @default(autoincrement()) @map("comment_id")
-  reportId    Int      @map("report_id")
-  managerId   Int      @map("manager_id")
-  comment     String   @db.Text
-  createdAt   DateTime @default(now()) @map("created_at")
+model Comment {
+  id         Int               @id @default(autoincrement())
+  reportId   Int               @map("report_id")
+  userId     Int               @map("user_id")
+  targetType CommentTargetType @map("target_type")
+  content    String            @db.Text
+  createdAt  DateTime          @default(now()) @map("created_at")
 
-  dailyReport DailyReport @relation(fields: [reportId], references: [reportId], onDelete: Cascade)
-  manager     SalesPerson @relation(fields: [managerId], references: [salesPersonId])
+  dailyReport DailyReport @relation(fields: [reportId], references: [id], onDelete: Cascade)
+  user        User        @relation(fields: [userId], references: [id])
 
-  @@map("manager_comments")
+  @@map("comments")
 }


### PR DESCRIPTION
## Summary

- 旧設計（`SalesPerson`, `ManagerComment`モデル）を廃止し、API仕様書準拠の新設計に全面刷新
- 新モデル: `Department`, `User`（`Role` enum付き）, `Customer`, `DailyReport`（`ReportStatus` enum付き）, `VisitRecord`, `Comment`（`CommentTargetType` enum付き）
- Prisma 7の破壊的変更に対応: datasource URLを`prisma.config.ts`へ移行
- 初期マイグレーションSQL (`prisma/migrations/0001_init/migration.sql`) を生成

## Test plan

- [ ] `DATABASE_URL="postgresql://dummy:dummy@localhost:5432/dummy" npx prisma validate` がパスすることを確認
- [ ] `prisma/migrations/0001_init/migration.sql` に全テーブル・enum・インデックス・外部キーが含まれていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)