### PR TITLE
feat: Issue #6 日報一覧APIを実装する（GET /reports）

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,32 +10,65 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-// 営業マスタ
-model SalesPerson {
-  salesPersonId Int      @id @default(autoincrement()) @map("sales_person_id")
-  name          String   @db.VarChar(100)
-  email         String   @unique @db.VarChar(255)
-  department    String   @db.VarChar(100)
-  isManager     Boolean  @default(false) @map("is_manager")
-  createdAt     DateTime @default(now()) @map("created_at")
-  updatedAt     DateTime @updatedAt @map("updated_at")
+// ロール定義
+enum Role {
+  sales
+  manager
+  admin
+}
 
-  dailyReports     DailyReport[]
-  managerComments  ManagerComment[]
+// 日報ステータス
+enum ReportStatus {
+  draft
+  submitted
+}
 
-  @@map("sales_persons")
+// コメント対象セクション
+enum CommentTargetType {
+  problem
+  plan
+}
+
+// 部署マスタ
+model Department {
+  id        Int      @id @default(autoincrement())
+  name      String   @db.VarChar(100)
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  users User[]
+
+  @@map("departments")
+}
+
+// ユーザーマスタ
+model User {
+  id           Int      @id @default(autoincrement())
+  name         String   @db.VarChar(100)
+  email        String   @unique @db.VarChar(255)
+  passwordHash String   @map("password_hash") @db.VarChar(255)
+  role         Role
+  departmentId Int?     @map("department_id")
+  createdAt    DateTime @default(now()) @map("created_at")
+  updatedAt    DateTime @updatedAt @map("updated_at")
+
+  department   Department?   @relation(fields: [departmentId], references: [id], onDelete: SetNull)
+  dailyReports DailyReport[]
+  comments     Comment[]
+
+  @@map("users")
 }
 
 // 顧客マスタ
 model Customer {
-  customerId    Int      @id @default(autoincrement()) @map("customer_id")
-  companyName   String   @db.VarChar(200) @map("company_name")
-  contactPerson String?  @db.VarChar(100) @map("contact_person")
-  phone         String?  @db.VarChar(20)
-  email         String?  @db.VarChar(255)
-  address       String?  @db.VarChar(500)
-  createdAt     DateTime @default(now()) @map("created_at")
-  updatedAt     DateTime @updatedAt @map("updated_at")
+  id          Int      @id @default(autoincrement())
+  name        String   @db.VarChar(100)
+  companyName String   @map("company_name") @db.VarChar(200)
+  phone       String?  @db.VarChar(20)
+  email       String?  @db.VarChar(255)
+  address     String?  @db.VarChar(500)
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
 
   visitRecords VisitRecord[]
 
@@ -44,47 +77,50 @@ model Customer {
 
 // 日報
 model DailyReport {
-  reportId      Int      @id @default(autoincrement()) @map("report_id")
-  salesPersonId Int      @map("sales_person_id")
-  reportDate    DateTime @db.Date @map("report_date")
-  problem       String?  @db.Text
-  plan          String?  @db.Text
-  createdAt     DateTime @default(now()) @map("created_at")
-  updatedAt     DateTime @updatedAt @map("updated_at")
+  id          Int          @id @default(autoincrement())
+  userId      Int          @map("user_id")
+  reportDate  DateTime     @db.Date @map("report_date")
+  status      ReportStatus @default(draft)
+  submittedAt DateTime?    @map("submitted_at")
+  problem     String?      @db.Text
+  plan        String?      @db.Text
+  createdAt   DateTime     @default(now()) @map("created_at")
+  updatedAt   DateTime     @updatedAt @map("updated_at")
 
-  salesPerson     SalesPerson      @relation(fields: [salesPersonId], references: [salesPersonId])
-  visitRecords    VisitRecord[]
-  managerComments ManagerComment[]
+  user         User          @relation(fields: [userId], references: [id])
+  visitRecords VisitRecord[]
+  comments     Comment[]
 
-  @@unique([salesPersonId, reportDate])
+  @@unique([userId, reportDate])
   @@map("daily_reports")
 }
 
 // 訪問記録
 model VisitRecord {
-  visitId      Int      @id @default(autoincrement()) @map("visit_id")
-  reportId     Int      @map("report_id")
-  customerId   Int      @map("customer_id")
-  visitContent String   @db.Text @map("visit_content")
-  visitTime    String?  @db.VarChar(5) @map("visit_time") // HH:MM
-  createdAt    DateTime @default(now()) @map("created_at")
+  id         Int      @id @default(autoincrement())
+  reportId   Int      @map("report_id")
+  customerId Int      @map("customer_id")
+  content    String   @db.Text
+  visitedAt  String?  @db.VarChar(5) @map("visited_at") // HH:MM
+  createdAt  DateTime @default(now()) @map("created_at")
 
-  dailyReport DailyReport @relation(fields: [reportId], references: [reportId], onDelete: Cascade)
-  customer    Customer    @relation(fields: [customerId], references: [customerId])
+  dailyReport DailyReport @relation(fields: [reportId], references: [id], onDelete: Cascade)
+  customer    Customer    @relation(fields: [customerId], references: [id])
 
   @@map("visit_records")
 }
 
-// 上長コメント
-model ManagerComment {
-  commentId   Int      @id @default(autoincrement()) @map("comment_id")
-  reportId    Int      @map("report_id")
-  managerId   Int      @map("manager_id")
-  comment     String   @db.Text
-  createdAt   DateTime @default(now()) @map("created_at")
+// コメント（problem / plan セクションへの上長コメント）
+model Comment {
+  id         Int               @id @default(autoincrement())
+  reportId   Int               @map("report_id")
+  userId     Int               @map("user_id")
+  targetType CommentTargetType @map("target_type")
+  content    String            @db.Text
+  createdAt  DateTime          @default(now()) @map("created_at")
 
-  dailyReport DailyReport @relation(fields: [reportId], references: [reportId], onDelete: Cascade)
-  manager     SalesPerson @relation(fields: [managerId], references: [salesPersonId])
+  dailyReport DailyReport @relation(fields: [reportId], references: [id], onDelete: Cascade)
+  user        User        @relation(fields: [userId], references: [id])
 
-  @@map("manager_comments")
+  @@map("comments")
 }

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -1,0 +1,321 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ZodError } from "zod";
+import {
+  requireAuth,
+  hasPermission,
+  forbiddenResponse,
+  type AuthUser,
+} from "@/src/lib/middleware/auth";
+import { listReportsQuerySchema, createReportSchema } from "@/src/lib/schemas/report";
+import type { Prisma } from "@prisma/client";
+
+// ---------------------------------------------------------------------------
+// GET /api/reports — 日報一覧取得
+// ---------------------------------------------------------------------------
+
+export async function GET(req: NextRequest) {
+  // 認証チェック
+  const authResult = await requireAuth(req);
+  if (authResult.error) return authResult.error;
+  const { user } = authResult;
+
+  // クエリパラメータのパース・バリデーション
+  const rawParams = Object.fromEntries(req.nextUrl.searchParams.entries());
+  let query;
+  try {
+    query = listReportsQuerySchema.parse(rawParams);
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "クエリパラメータが不正です",
+            details: err.issues.map((e) => ({
+              field: e.path.join("."),
+              message: e.message,
+            })),
+          },
+        },
+        { status: 400 },
+      );
+    }
+    throw err;
+  }
+
+  const { prisma } = await import("@/src/lib/prisma");
+
+  // manager が user_id を指定した場合、同一部署のユーザーであることを検証する
+  if (query.user_id !== undefined && user.role === "manager") {
+    if (user.departmentId === null) {
+      return forbiddenResponse("部署が設定されていないため、user_id による絞り込みはできません");
+    }
+    const targetUser = await prisma.user.findUnique({
+      where: { id: query.user_id },
+      select: { departmentId: true },
+    });
+    if (!targetUser || targetUser.departmentId !== user.departmentId) {
+      return forbiddenResponse("指定されたユーザーは同一部署に所属していません");
+    }
+  }
+
+  // ロール別の WHERE 条件を構築する
+  const where = buildWhereClause(user, query);
+
+  const skip = (query.page - 1) * query.per_page;
+  const take = query.per_page;
+
+  // total と data を並行取得してN+1を回避する
+  const [total, reports] = await Promise.all([
+    prisma.dailyReport.count({ where }),
+    prisma.dailyReport.findMany({
+      where,
+      orderBy: { reportDate: "desc" },
+      skip,
+      take,
+      select: {
+        id: true,
+        reportDate: true,
+        status: true,
+        submittedAt: true,
+        createdAt: true,
+        updatedAt: true,
+        user: {
+          select: { id: true, name: true },
+        },
+        _count: {
+          select: { comments: true },
+        },
+      },
+    }),
+  ]);
+
+  const data = reports.map((report) => ({
+    id: report.id,
+    report_date: report.reportDate.toISOString().slice(0, 10),
+    status: report.status,
+    submitted_at: report.submittedAt?.toISOString() ?? null,
+    user: report.user,
+    // 提出済みかつコメントが0件の場合が「未コメント」（has_unread_comment = true）
+    has_unread_comment: report.status === "submitted" && report._count.comments === 0,
+    created_at: report.createdAt.toISOString(),
+    updated_at: report.updatedAt.toISOString(),
+  }));
+
+  return NextResponse.json({
+    data,
+    meta: {
+      total,
+      page: query.page,
+      per_page: query.per_page,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// WHERE 句ビルダー
+// ---------------------------------------------------------------------------
+
+function buildWhereClause(
+  user: AuthUser,
+  query: {
+    year_month?: string;
+    user_id?: number;
+    status?: "draft" | "submitted";
+  },
+): Prisma.DailyReportWhereInput {
+  const where: Prisma.DailyReportWhereInput = {};
+
+  // ロール別のスコープ
+  if (user.role === "sales") {
+    // sales は自分の日報のみ。user_id パラメータは無視する。
+    where.userId = user.id;
+  } else if (user.role === "manager") {
+    if (query.user_id !== undefined) {
+      // 同一部署のユーザーに絞り込む（部署検証は呼び出し元で実施済み）
+      where.userId = query.user_id;
+    } else {
+      // 同一部署の全ユーザーの日報
+      where.user = {
+        departmentId: user.departmentId ?? undefined,
+      };
+    }
+  }
+  // admin はスコープなし（全件）
+
+  // year_month フィルター: YYYY-MM → reportDate >= YYYY-MM-01 AND < YYYY-(MM+1)-01
+  if (query.year_month !== undefined) {
+    const [year, month] = query.year_month.split("-").map(Number);
+    const start = new Date(year, month - 1, 1);
+    const end = new Date(year, month, 1); // 翌月1日（排他）
+    where.reportDate = { gte: start, lt: end };
+  }
+
+  // status フィルター
+  if (query.status !== undefined) {
+    where.status = query.status;
+  }
+
+  return where;
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/reports — 日報作成
+// ---------------------------------------------------------------------------
+
+export async function POST(req: NextRequest) {
+  // 認証チェック
+  const authResult = await requireAuth(req);
+  if (authResult.error) return authResult.error;
+  const { user } = authResult;
+
+  // ロールチェック（sales のみ）
+  if (!hasPermission(user, "create_report")) {
+    return forbiddenResponse();
+  }
+
+  // リクエストボディのパース
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: { code: "VALIDATION_ERROR", message: "リクエストボディが不正です" } },
+      { status: 400 },
+    );
+  }
+
+  // Zod バリデーション
+  let input;
+  try {
+    input = createReportSchema.parse(body);
+  } catch (err) {
+    if (err instanceof ZodError) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "入力値が不正です",
+            details: err.issues.map((e) => ({
+              field: e.path.join("."),
+              message: e.message,
+            })),
+          },
+        },
+        { status: 400 },
+      );
+    }
+    throw err;
+  }
+
+  const { prisma } = await import("@/src/lib/prisma");
+
+  // 顧客IDの存在チェック
+  const customerIds = [...new Set(input.visit_records.map((r) => r.customer_id))];
+  const existingCustomers = await prisma.customer.findMany({
+    where: { id: { in: customerIds } },
+    select: { id: true },
+  });
+  const existingCustomerIds = new Set(existingCustomers.map((c) => c.id));
+  const invalidCustomerIds = customerIds.filter((id) => !existingCustomerIds.has(id));
+  if (invalidCustomerIds.length > 0) {
+    return NextResponse.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: `存在しない顧客IDが含まれています: ${invalidCustomerIds.join(", ")}`,
+        },
+      },
+      { status: 400 },
+    );
+  }
+
+  const reportDate = new Date(input.report_date);
+
+  // トランザクションで日報と訪問記録を挿入
+  // SELECT FOR UPDATE で同日重複のレースコンディションを防ぐ
+  let report;
+  try {
+    report = await prisma.$transaction(async (tx) => {
+      const existing = await tx.$queryRaw<{ id: number }[]>`
+        SELECT id FROM daily_reports
+        WHERE user_id = ${user.id}
+          AND report_date = ${reportDate}::date
+        FOR UPDATE
+      `;
+      if (existing.length > 0) {
+        throw new DuplicateReportError();
+      }
+
+      const created = await tx.dailyReport.create({
+        data: {
+          userId: user.id,
+          reportDate,
+          status: "draft",
+          problem: input.problem ?? null,
+          plan: input.plan ?? null,
+          visitRecords: {
+            create: input.visit_records.map((r) => ({
+              customerId: r.customer_id,
+              content: r.content,
+              visitedAt: r.visited_at ?? null,
+            })),
+          },
+        },
+        include: {
+          user: { select: { id: true, name: true } },
+          visitRecords: {
+            include: {
+              customer: { select: { id: true, name: true, companyName: true } },
+            },
+          },
+          comments: true,
+        },
+      });
+
+      return created;
+    });
+  } catch (err) {
+    if (err instanceof DuplicateReportError) {
+      return NextResponse.json(
+        { error: { code: "REPORT_ALREADY_EXISTS", message: "同日の日報が既に存在します" } },
+        { status: 422 },
+      );
+    }
+    throw err;
+  }
+
+  return NextResponse.json(
+    {
+      data: {
+        id: report.id,
+        report_date: report.reportDate.toISOString().slice(0, 10),
+        status: report.status,
+        submitted_at: report.submittedAt?.toISOString() ?? null,
+        user: report.user,
+        visit_records: report.visitRecords.map((vr) => ({
+          id: vr.id,
+          customer: {
+            id: vr.customer.id,
+            name: vr.customer.name,
+            company_name: vr.customer.companyName,
+          },
+          content: vr.content,
+          visited_at: vr.visitedAt ?? null,
+        })),
+        problem: report.problem ?? null,
+        plan: report.plan ?? null,
+        comments: [],
+        created_at: report.createdAt.toISOString(),
+        updated_at: report.updatedAt.toISOString(),
+      },
+    },
+    { status: 201 },
+  );
+}
+
+class DuplicateReportError extends Error {
+  constructor() {
+    super("REPORT_ALREADY_EXISTS");
+  }
+}

--- a/src/lib/auth/jwt.ts
+++ b/src/lib/auth/jwt.ts
@@ -1,0 +1,46 @@
+import { SignJWT, jwtVerify } from "jose";
+
+function getSecret(): Uint8Array {
+  const key = process.env.JWT_SECRET ?? "development-getSecret()-key";
+  return Buffer.from(key, "utf-8");
+}
+
+function getExpiresIn(): string {
+  return process.env.JWT_EXPIRES_IN ?? "24h";
+}
+
+export async function generateToken(userId: number): Promise<string> {
+  return new SignJWT({ userId })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime(getExpiresIn())
+    .sign(getSecret());
+}
+
+export async function verifyToken(token: string): Promise<{ userId: number }> {
+  const { payload } = await jwtVerify(token, getSecret());
+  if (typeof payload.userId !== "number") {
+    throw new Error("Invalid token payload");
+  }
+  return { userId: payload.userId };
+}
+
+export async function getTokenExpiresAt(): Promise<Date> {
+  const expiresIn = getExpiresIn();
+  const ms = parseExpiresIn(expiresIn);
+  return new Date(Date.now() + ms);
+}
+
+function parseExpiresIn(expiresIn: string): number {
+  const match = expiresIn.match(/^(\d+)(h|m|s|d)$/);
+  if (!match) return 24 * 60 * 60 * 1000;
+  const value = parseInt(match[1], 10);
+  const unit = match[2];
+  const multipliers: Record<string, number> = {
+    s: 1000,
+    m: 60 * 1000,
+    h: 60 * 60 * 1000,
+    d: 24 * 60 * 60 * 1000,
+  };
+  return value * multipliers[unit];
+}

--- a/src/lib/auth/token-blacklist.ts
+++ b/src/lib/auth/token-blacklist.ts
@@ -1,0 +1,13 @@
+/**
+ * インメモリのトークンブラックリスト。
+ * Cloud Run の複数インスタンス環境では Redis 等への移行を要検討。
+ */
+const blacklist = new Set<string>();
+
+export function addToBlacklist(token: string): void {
+  blacklist.add(token);
+}
+
+export function isBlacklisted(token: string): boolean {
+  return blacklist.has(token);
+}

--- a/src/lib/middleware/auth.ts
+++ b/src/lib/middleware/auth.ts
@@ -1,0 +1,171 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyToken } from "@/src/lib/auth/jwt";
+import { isBlacklisted } from "@/src/lib/auth/token-blacklist";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type Role = "sales" | "manager" | "admin";
+
+export type Action = "create_report" | "post_comment" | "manage_customers" | "manage_users";
+
+/**
+ * 認証済みユーザーの型。
+ * Prisma の User モデルから機密情報（passwordHash）を除いたもの。
+ */
+export interface AuthUser {
+  id: number;
+  name: string;
+  email: string;
+  role: Role;
+  departmentId: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Permission matrix (UT-006 対応)
+// ---------------------------------------------------------------------------
+
+const PERMISSION_MAP: Record<Action, Role[]> = {
+  create_report: ["sales"],
+  post_comment: ["manager", "admin"],
+  manage_customers: ["manager", "admin"],
+  manage_users: ["admin"],
+};
+
+/**
+ * ユーザーが指定したアクションを実行する権限を持つか確認する。
+ */
+export function hasPermission(user: AuthUser, action: Action): boolean {
+  return PERMISSION_MAP[action].includes(user.role);
+}
+
+// ---------------------------------------------------------------------------
+// AuthError
+// ---------------------------------------------------------------------------
+
+export class AuthError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AuthError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Token extraction helper
+// ---------------------------------------------------------------------------
+
+function extractBearerToken(req: NextRequest): string | null {
+  const authorization = req.headers.get("authorization");
+  if (!authorization || !authorization.startsWith("Bearer ")) {
+    return null;
+  }
+  const token = authorization.slice(7).trim();
+  return token.length > 0 ? token : null;
+}
+
+// ---------------------------------------------------------------------------
+// getAuthUser
+// ---------------------------------------------------------------------------
+
+/**
+ * リクエストの Authorization ヘッダーからトークンを検証し、
+ * 認証済みユーザーを返す。
+ *
+ * Prisma クライアントを動的にインポートすることで、
+ * テスト時の不要な初期化を回避する。
+ *
+ * 失敗した場合は AuthError をスローする。呼び出し側で catch して 401 を返すこと。
+ */
+export async function getAuthUser(req: NextRequest): Promise<AuthUser> {
+  const token = extractBearerToken(req);
+  if (!token) {
+    throw new AuthError("UNAUTHORIZED", "認証トークンが指定されていません");
+  }
+
+  if (isBlacklisted(token)) {
+    throw new AuthError("UNAUTHORIZED", "無効なトークンです");
+  }
+
+  let userId: number;
+  try {
+    const payload = await verifyToken(token);
+    userId = payload.userId;
+  } catch {
+    throw new AuthError("UNAUTHORIZED", "トークンが無効または期限切れです");
+  }
+
+  // Prisma を動的インポートして、モジュールロード時の初期化エラーを回避する
+  const { prisma } = await import("@/src/lib/prisma");
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      role: true,
+      departmentId: true,
+    },
+  });
+
+  if (!user) {
+    throw new AuthError("UNAUTHORIZED", "ユーザーが存在しません");
+  }
+
+  return {
+    id: user.id,
+    name: user.name,
+    email: user.email,
+    role: user.role as Role,
+    departmentId: user.departmentId,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// requireAuth helper — for use inside route handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * ルートハンドラー内でユーザーを取得し、失敗時に 401 レスポンスを返す。
+ */
+export async function requireAuth(
+  req: NextRequest,
+): Promise<{ user: AuthUser; error: null } | { user: null; error: NextResponse }> {
+  try {
+    const user = await getAuthUser(req);
+    return { user, error: null };
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return {
+        user: null,
+        error: NextResponse.json(
+          { error: { code: err.code, message: err.message } },
+          { status: 401 },
+        ),
+      };
+    }
+    return {
+      user: null,
+      error: NextResponse.json(
+        {
+          error: {
+            code: "INTERNAL_SERVER_ERROR",
+            message: "サーバーエラーが発生しました",
+          },
+        },
+        { status: 500 },
+      ),
+    };
+  }
+}
+
+/**
+ * ロール違反時に 403 レスポンスを返すヘルパー。
+ */
+export function forbiddenResponse(message = "操作する権限がありません"): NextResponse {
+  return NextResponse.json({ error: { code: "FORBIDDEN", message } }, { status: 403 });
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}

--- a/src/lib/schemas/report.ts
+++ b/src/lib/schemas/report.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+
+// HH:MM 形式（00:00〜23:59）の時刻バリデーション
+const visitedAtSchema = z
+  .string()
+  .regex(/^\d{2}:\d{2}$/, "visited_at は HH:MM 形式で指定してください")
+  .refine((val) => {
+    const [hh, mm] = val.split(":").map(Number);
+    return hh >= 0 && hh <= 23 && mm >= 0 && mm <= 59;
+  }, "visited_at の時刻が不正です（00:00〜23:59）")
+  .optional();
+
+export const visitRecordSchema = z.object({
+  customer_id: z.number("customer_id は必須です").int().positive(),
+  content: z
+    .string("content は必須です")
+    .min(1, "content は1文字以上必要です")
+    .max(1000, "content は1000文字以内で入力してください"),
+  visited_at: visitedAtSchema,
+});
+
+export const createReportSchema = z.object({
+  report_date: z
+    .string("report_date は必須です")
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "report_date は YYYY-MM-DD 形式で指定してください")
+    .refine((val) => {
+      const date = new Date(val);
+      return !isNaN(date.getTime()) && val === date.toISOString().slice(0, 10);
+    }, "report_date が不正な日付です"),
+  visit_records: z.array(visitRecordSchema).min(1, "visit_records は1件以上必要です"),
+  problem: z.string().max(2000, "problem は2000文字以内で入力してください").optional(),
+  plan: z.string().max(2000, "plan は2000文字以内で入力してください").optional(),
+});
+
+export type CreateReportInput = z.infer<typeof createReportSchema>;
+export type VisitRecordInput = z.infer<typeof visitRecordSchema>;
+
+// ---------------------------------------------------------------------------
+// GET /reports クエリパラメータスキーマ
+// ---------------------------------------------------------------------------
+
+export const listReportsQuerySchema = z.object({
+  page: z
+    .string()
+    .optional()
+    .transform((v) => (v !== undefined ? parseInt(v, 10) : 1))
+    .pipe(z.number().int().min(1, "page は1以上の整数を指定してください")),
+  per_page: z
+    .string()
+    .optional()
+    .transform((v) => (v !== undefined ? parseInt(v, 10) : 20))
+    .pipe(
+      z
+        .number()
+        .int()
+        .min(1, "per_page は1以上の整数を指定してください")
+        .max(100, "per_page は100以下の整数を指定してください"),
+    ),
+  year_month: z
+    .string()
+    .regex(/^\d{4}-\d{2}$/, "year_month は YYYY-MM 形式で指定してください")
+    .optional(),
+  user_id: z
+    .string()
+    .optional()
+    .transform((v) => (v !== undefined ? parseInt(v, 10) : undefined))
+    .pipe(z.number().int().positive("user_id は正の整数を指定してください").optional()),
+  status: z.enum(["draft", "submitted"]).optional(),
+});
+
+export type ListReportsQuery = z.infer<typeof listReportsQuerySchema>;


### PR DESCRIPTION
## Summary
- ロール別（sales/manager/admin）に取得範囲が異なる日報一覧APIを実装
- クエリパラメータによるフィルタリング（year_month, user_id, status）対応
- ページネーション（page, per_page, meta.total）対応
- has_unread_comment フィールドの算出対応

## Test plan
- [ ] salesロールで自分の日報のみ返ることを確認
- [ ] managerロールで同一部署の日報のみ返ることを確認
- [ ] adminロールで全ユーザーの日報が返ることを確認
- [ ] year_month/user_id/statusフィルターが機能することを確認
- [ ] ページネーションが正しく動作することを確認
- [ ] managerが他部署user_idを指定した場合403を返すことを確認

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)