### PR TITLE
feat: Issue #10 ユーザーマスタAPIを実装する（GET/POST/PUT /users）

### DIFF
--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,0 +1,149 @@
+import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { prisma } from "@/src/lib/prisma";
+import { withAuth, requireRole } from "@/src/lib/middleware/auth";
+import { userUpdateSchema } from "@/src/lib/schemas/user";
+import type { JwtPayload } from "@/src/lib/auth/jwt";
+import type { User, Department } from "@prisma/client";
+
+type UserWithDepartment = User & { department: Department | null };
+
+function formatUser(u: UserWithDepartment) {
+  return {
+    id: u.id,
+    name: u.name,
+    email: u.email,
+    role: u.role,
+    department: u.department ? { id: u.department.id, name: u.department.name } : null,
+    created_at: u.createdAt.toISOString(),
+  };
+}
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export function GET(req: NextRequest, ctx: RouteContext) {
+  return withAuth(
+    requireRole(["admin"], async (_req: NextRequest, _user: JwtPayload) => {
+      const { id } = await ctx.params;
+      const userId = parseInt(id, 10);
+      if (isNaN(userId)) {
+        return NextResponse.json(
+          { error: { code: "NOT_FOUND", message: "ユーザーが見つかりません" } },
+          { status: 404 },
+        );
+      }
+
+      const user = await prisma.user.findUnique({
+        where: { id: userId },
+        include: { department: true },
+      });
+      if (!user) {
+        return NextResponse.json(
+          { error: { code: "NOT_FOUND", message: "ユーザーが見つかりません" } },
+          { status: 404 },
+        );
+      }
+
+      return NextResponse.json({ data: formatUser(user) });
+    }),
+  )(req);
+}
+
+export function PUT(req: NextRequest, ctx: RouteContext) {
+  return withAuth(
+    requireRole(["admin"], async (req: NextRequest, _user: JwtPayload) => {
+      const { id } = await ctx.params;
+      const userId = parseInt(id, 10);
+      if (isNaN(userId)) {
+        return NextResponse.json(
+          { error: { code: "NOT_FOUND", message: "ユーザーが見つかりません" } },
+          { status: 404 },
+        );
+      }
+
+      const existing = await prisma.user.findUnique({ where: { id: userId } });
+      if (!existing) {
+        return NextResponse.json(
+          { error: { code: "NOT_FOUND", message: "ユーザーが見つかりません" } },
+          { status: 404 },
+        );
+      }
+
+      let body: unknown;
+      try {
+        body = await req.json();
+      } catch {
+        return NextResponse.json(
+          { error: { code: "INVALID_JSON", message: "JSONが不正です" } },
+          { status: 400 },
+        );
+      }
+
+      const parsed = userUpdateSchema.safeParse(body);
+      if (!parsed.success) {
+        return NextResponse.json(
+          {
+            error: {
+              code: "VALIDATION_ERROR",
+              message: "入力値が不正です",
+              details: parsed.error.issues,
+            },
+          },
+          { status: 400 },
+        );
+      }
+
+      const { name, email, password, role, department_id } = parsed.data;
+
+      // メール重複チェック（変更時のみ）
+      if (email && email !== existing.email) {
+        const dup = await prisma.user.findUnique({ where: { email } });
+        if (dup) {
+          return NextResponse.json(
+            {
+              error: {
+                code: "EMAIL_ALREADY_EXISTS",
+                message: "このメールアドレスは既に使用されています",
+              },
+            },
+            { status: 400 },
+          );
+        }
+      }
+
+      // 部署存在チェック
+      if (department_id) {
+        const dept = await prisma.department.findUnique({
+          where: { id: department_id },
+        });
+        if (!dept) {
+          return NextResponse.json(
+            {
+              error: {
+                code: "DEPARTMENT_NOT_FOUND",
+                message: "指定された部署が存在しません",
+              },
+            },
+            { status: 400 },
+          );
+        }
+      }
+
+      const passwordHash = password ? await bcrypt.hash(password, 10) : undefined;
+
+      const user = await prisma.user.update({
+        where: { id: userId },
+        data: {
+          ...(name !== undefined && { name }),
+          ...(email !== undefined && { email }),
+          ...(passwordHash !== undefined && { passwordHash }),
+          ...(role !== undefined && { role }),
+          ...(department_id !== undefined && { departmentId: department_id }),
+        },
+        include: { department: true },
+      });
+
+      return NextResponse.json({ data: formatUser(user) });
+    }),
+  )(req);
+}

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,0 +1,145 @@
+import { NextRequest, NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { prisma } from "@/src/lib/prisma";
+import { withAuth, requireRole } from "@/src/lib/middleware/auth";
+import { userCreateSchema, userListQuerySchema } from "@/src/lib/schemas/user";
+import type { JwtPayload } from "@/src/lib/auth/jwt";
+import type { User, Department } from "@prisma/client";
+
+type UserWithDepartment = User & { department: Department | null };
+
+function formatUser(u: UserWithDepartment) {
+  return {
+    id: u.id,
+    name: u.name,
+    email: u.email,
+    role: u.role,
+    department: u.department ? { id: u.department.id, name: u.department.name } : null,
+    created_at: u.createdAt.toISOString(),
+  };
+}
+
+export const GET = withAuth(
+  requireRole(["admin"], async (req: NextRequest, _user: JwtPayload): Promise<NextResponse> => {
+    const { searchParams } = new URL(req.url);
+    const parsed = userListQuerySchema.safeParse({
+      role: searchParams.get("role") ?? undefined,
+      department_id: searchParams.get("department_id") ?? undefined,
+      page: searchParams.get("page") ?? undefined,
+      per_page: searchParams.get("per_page") ?? undefined,
+    });
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "クエリパラメータが不正です",
+            details: parsed.error.issues,
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    const { role, department_id, page, per_page } = parsed.data;
+    const skip = (page - 1) * per_page;
+
+    const where = {
+      ...(role && { role }),
+      ...(department_id && { departmentId: department_id }),
+    };
+
+    const [users, total] = await Promise.all([
+      prisma.user.findMany({
+        where,
+        include: { department: true },
+        skip,
+        take: per_page,
+        orderBy: { createdAt: "desc" },
+      }),
+      prisma.user.count({ where }),
+    ]);
+
+    return NextResponse.json({
+      data: users.map(formatUser),
+      meta: { total, page, per_page },
+    });
+  }),
+);
+
+export const POST = withAuth(
+  requireRole(["admin"], async (req: NextRequest, _user: JwtPayload): Promise<NextResponse> => {
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return NextResponse.json(
+        { error: { code: "INVALID_JSON", message: "JSONが不正です" } },
+        { status: 400 },
+      );
+    }
+
+    const parsed = userCreateSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "入力値が不正です",
+            details: parsed.error.issues,
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    const { name, email, password, role, department_id } = parsed.data;
+
+    // メール重複チェック
+    const existing = await prisma.user.findUnique({ where: { email } });
+    if (existing) {
+      return NextResponse.json(
+        {
+          error: {
+            code: "EMAIL_ALREADY_EXISTS",
+            message: "このメールアドレスは既に使用されています",
+          },
+        },
+        { status: 400 },
+      );
+    }
+
+    // 部署存在チェック（admin以外は必須）
+    if (department_id) {
+      const dept = await prisma.department.findUnique({
+        where: { id: department_id },
+      });
+      if (!dept) {
+        return NextResponse.json(
+          {
+            error: {
+              code: "DEPARTMENT_NOT_FOUND",
+              message: "指定された部署が存在しません",
+            },
+          },
+          { status: 400 },
+        );
+      }
+    }
+
+    const passwordHash = await bcrypt.hash(password, 10);
+    const user = await prisma.user.create({
+      data: {
+        name,
+        email,
+        passwordHash,
+        role,
+        departmentId: department_id ?? null,
+      },
+      include: { department: true },
+    });
+
+    return NextResponse.json({ data: formatUser(user) }, { status: 201 });
+  }),
+);

--- a/src/lib/auth/jwt.ts
+++ b/src/lib/auth/jwt.ts
@@ -1,0 +1,14 @@
+import { jwtVerify } from "jose";
+
+export type JwtPayload = {
+  sub: string;
+  role: "sales" | "manager" | "admin";
+  department: string;
+  name: string;
+};
+
+export async function verifyToken(token: string): Promise<JwtPayload> {
+  const secret = new TextEncoder().encode(process.env.JWT_SECRET ?? "dev-secret");
+  const { payload } = await jwtVerify(token, secret);
+  return payload as unknown as JwtPayload;
+}

--- a/src/lib/middleware/auth.ts
+++ b/src/lib/middleware/auth.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyToken, type JwtPayload } from "@/src/lib/auth/jwt";
+
+export type AuthenticatedHandler = (req: NextRequest, user: JwtPayload) => Promise<NextResponse>;
+
+export function withAuth(handler: AuthenticatedHandler) {
+  return async (req: NextRequest): Promise<NextResponse> => {
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+      return NextResponse.json(
+        { error: { code: "UNAUTHORIZED", message: "認証が必要です" } },
+        { status: 401 },
+      );
+    }
+
+    const token = authHeader.slice(7);
+    try {
+      const user = await verifyToken(token);
+      return handler(req, user);
+    } catch {
+      return NextResponse.json(
+        { error: { code: "UNAUTHORIZED", message: "トークンが無効です" } },
+        { status: 401 },
+      );
+    }
+  };
+}
+
+export function requireRole(
+  roles: Array<"sales" | "manager" | "admin">,
+  handler: AuthenticatedHandler,
+): AuthenticatedHandler {
+  return async (req, user) => {
+    if (!roles.includes(user.role)) {
+      return NextResponse.json(
+        { error: { code: "FORBIDDEN", message: "権限がありません" } },
+        { status: 403 },
+      );
+    }
+    return handler(req, user);
+  };
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,7 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/src/lib/schemas/user.ts
+++ b/src/lib/schemas/user.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export const userCreateSchema = z.object({
+  name: z.string().min(1).max(100),
+  email: z.string().email().max(255),
+  password: z.string().min(8),
+  role: z.enum(["sales", "manager", "admin"]),
+  department_id: z.number().int().positive().nullable().optional(),
+});
+
+export const userUpdateSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  email: z.string().email().max(255).optional(),
+  password: z.string().min(8).optional(),
+  role: z.enum(["sales", "manager", "admin"]).optional(),
+  department_id: z.number().int().positive().nullable().optional(),
+});
+
+export const userListQuerySchema = z.object({
+  role: z.enum(["sales", "manager", "admin"]).optional(),
+  department_id: z.coerce.number().int().positive().optional(),
+  page: z.coerce.number().int().positive().default(1),
+  per_page: z.coerce.number().int().positive().max(100).default(50),
+});
+
+export type UserCreateInput = z.infer<typeof userCreateSchema>;
+export type UserUpdateInput = z.infer<typeof userUpdateSchema>;
+export type UserListQuery = z.infer<typeof userListQuerySchema>;


### PR DESCRIPTION
## Summary
- GET /api/users: ページネーション・role/department_id フィルター（admin のみ）
- POST /api/users: bcrypt パスワードハッシュ化・メール重複チェック付きユーザー作成
- GET /api/users/:id: ユーザー詳細取得（admin のみ）
- PUT /api/users/:id: 部分更新・パスワード省略時は変更なし（admin のみ）

## Test plan
- [ ] admin 以外で全エンドポイントが 403 を返すことを確認
- [ ] POST /api/users でユーザーを作成できることを確認（IT-009）
- [ ] 重複メールで 400 EMAIL_ALREADY_EXISTS を返すことを確認
- [ ] パスワードが bcrypt ハッシュ化されて保存されることを確認
- [ ] PUT /api/users/:id でパスワード省略時に変更されないことを確認

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)