### PR TITLE
feat: Issue #12 ダッシュボード（日報一覧）画面を実装

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+import { Suspense } from "react";
+import { getCurrentUser } from "@/src/lib/auth";
+import { getReports, getFilterUsers } from "@/src/lib/mockData";
+import { FilterBar } from "@/src/components/dashboard/FilterBar";
+import { ReportList } from "@/src/components/dashboard/ReportList";
+import { Pagination } from "@/src/components/dashboard/Pagination";
+
+interface DashboardPageProps {
+  searchParams: Promise<{
+    page?: string;
+    year_month?: string;
+    user_id?: string;
+    status?: string;
+  }>;
+}
+
+export default async function DashboardPage({ searchParams }: DashboardPageProps) {
+  const params = await searchParams;
+  const user = getCurrentUser();
+  const filterUsers = getFilterUsers();
+
+  const page = Number(params.page) || 1;
+  const userIdParam = params.user_id ? Number(params.user_id) : undefined;
+
+  // Sales users can only see their own reports
+  const effectiveUserId = user.role === "sales" ? user.id : userIdParam;
+
+  const { data: reports, meta } = getReports({
+    page,
+    per_page: 20,
+    year_month: params.year_month,
+    user_id: effectiveUserId,
+    status: params.status,
+  });
+
+  const showCreateButton = user.role === "sales";
+
+  return (
+    <div>
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <h2 className="text-xl font-bold text-gray-900">日報一覧</h2>
+        {showCreateButton && (
+          <Link
+            href="/reports/new"
+            className="inline-flex items-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none"
+          >
+            + 日報を作成
+          </Link>
+        )}
+      </div>
+
+      <div className="mb-4">
+        <Suspense fallback={null}>
+          <FilterBar role={user.role} users={filterUsers} />
+        </Suspense>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+        <ReportList reports={reports} role={user.role} />
+        <Pagination meta={meta} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,0 +1,13 @@
+import { Header } from "@/src/components/layout/Header";
+import { getCurrentUser } from "@/src/lib/auth";
+
+export default function AppLayout({ children }: { children: React.ReactNode }) {
+  const user = getCurrentUser();
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Header user={user} />
+      <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">{children}</main>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,5 @@
+import "./globals.css";
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja">

--- a/src/components/dashboard/FilterBar.tsx
+++ b/src/components/dashboard/FilterBar.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+import type { Role, ReportUser } from "@/src/types";
+
+interface FilterBarProps {
+  role: Role;
+  users: ReportUser[];
+}
+
+export function FilterBar({ role, users }: FilterBarProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const currentYearMonth = searchParams.get("year_month") ?? "";
+  const currentUserId = searchParams.get("user_id") ?? "";
+  const currentStatus = searchParams.get("status") ?? "";
+
+  const updateFilter = useCallback(
+    (key: string, value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value) {
+        params.set(key, value);
+      } else {
+        params.delete(key);
+      }
+      // Reset to page 1 when filters change
+      params.delete("page");
+      router.push(`/dashboard?${params.toString()}`);
+    },
+    [router, searchParams],
+  );
+
+  const showUserFilter = role === "manager" || role === "admin";
+
+  // Generate year-month options (past 12 months)
+  const yearMonthOptions = generateYearMonthOptions();
+
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+      <span className="text-sm font-medium text-gray-700">絞り込み:</span>
+
+      <select
+        aria-label="年月"
+        value={currentYearMonth}
+        onChange={(e) => updateFilter("year_month", e.target.value)}
+        className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+      >
+        <option value="">全期間</option>
+        {yearMonthOptions.map((ym) => (
+          <option key={ym.value} value={ym.value}>
+            {ym.label}
+          </option>
+        ))}
+      </select>
+
+      {showUserFilter && (
+        <select
+          aria-label="営業担当"
+          value={currentUserId}
+          onChange={(e) => updateFilter("user_id", e.target.value)}
+          className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+        >
+          <option value="">全担当者</option>
+          {users.map((user) => (
+            <option key={user.id} value={String(user.id)}>
+              {user.name}
+            </option>
+          ))}
+        </select>
+      )}
+
+      <select
+        aria-label="ステータス"
+        value={currentStatus}
+        onChange={(e) => updateFilter("status", e.target.value)}
+        className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+      >
+        <option value="">全ステータス</option>
+        <option value="draft">下書き</option>
+        <option value="submitted">提出済み</option>
+      </select>
+    </div>
+  );
+}
+
+function generateYearMonthOptions(): { value: string; label: string }[] {
+  const options: { value: string; label: string }[] = [];
+  const now = new Date();
+
+  for (let i = 0; i < 12; i++) {
+    const date = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    options.push({
+      value: `${year}-${month}`,
+      label: `${year}年${date.getMonth() + 1}月`,
+    });
+  }
+
+  return options;
+}

--- a/src/components/dashboard/Pagination.tsx
+++ b/src/components/dashboard/Pagination.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+import type { PaginationMeta } from "@/src/types";
+
+interface PaginationProps {
+  meta: PaginationMeta;
+}
+
+export function Pagination({ meta }: PaginationProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const totalPages = Math.ceil(meta.total / meta.per_page);
+
+  const goToPage = useCallback(
+    (page: number) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (page > 1) {
+        params.set("page", String(page));
+      } else {
+        params.delete("page");
+      }
+      router.push(`/dashboard?${params.toString()}`);
+    },
+    [router, searchParams],
+  );
+
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  return (
+    <nav
+      aria-label="ページネーション"
+      className="flex items-center justify-between border-t border-gray-200 px-4 py-3 sm:px-0"
+    >
+      <div className="text-sm text-gray-700">
+        全 <span className="font-medium">{meta.total}</span> 件中{" "}
+        <span className="font-medium">{(meta.page - 1) * meta.per_page + 1}</span>
+        {" - "}
+        <span className="font-medium">{Math.min(meta.page * meta.per_page, meta.total)}</span>{" "}
+        件を表示
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => goToPage(meta.page - 1)}
+          disabled={meta.page <= 1}
+          className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          前へ
+        </button>
+        <button
+          type="button"
+          onClick={() => goToPage(meta.page + 1)}
+          disabled={meta.page >= totalPages}
+          className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          次へ
+        </button>
+      </div>
+    </nav>
+  );
+}

--- a/src/components/dashboard/ReportList.tsx
+++ b/src/components/dashboard/ReportList.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import type { Report, Role } from "@/src/types";
+import { STATUS_LABELS } from "@/src/types";
+
+interface ReportListProps {
+  reports: Report[];
+  role: Role;
+}
+
+export function ReportList({ reports, role }: ReportListProps) {
+  const router = useRouter();
+  const showUserColumn = role === "manager" || role === "admin";
+
+  if (reports.length === 0) {
+    return <div className="py-12 text-center text-gray-500">日報がありません。</div>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            <th
+              scope="col"
+              className="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase"
+            >
+              日付
+            </th>
+            {showUserColumn && (
+              <th
+                scope="col"
+                className="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase"
+              >
+                担当者
+              </th>
+            )}
+            <th
+              scope="col"
+              className="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase"
+            >
+              ステータス
+            </th>
+            <th
+              scope="col"
+              className="px-4 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase"
+            >
+              コメント
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200 bg-white">
+          {reports.map((report) => (
+            <tr
+              key={report.id}
+              onClick={() => router.push(`/reports/${report.id}`)}
+              className="cursor-pointer transition-colors hover:bg-gray-50"
+              role="link"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  router.push(`/reports/${report.id}`);
+                }
+              }}
+            >
+              <td className="px-4 py-3 text-sm whitespace-nowrap text-gray-900">
+                {formatDate(report.report_date)}
+              </td>
+              {showUserColumn && (
+                <td className="px-4 py-3 text-sm whitespace-nowrap text-gray-900">
+                  {report.user.name}
+                </td>
+              )}
+              <td className="px-4 py-3 text-sm whitespace-nowrap">
+                <StatusBadge status={report.status} />
+              </td>
+              <td className="px-4 py-3 text-sm whitespace-nowrap text-gray-500">
+                <CommentIndicator report={report} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: Report["status"] }) {
+  const label = STATUS_LABELS[status];
+  const className =
+    status === "submitted"
+      ? "inline-flex rounded-full bg-green-100 px-2 py-1 text-xs font-semibold leading-5 text-green-800"
+      : "inline-flex rounded-full bg-gray-100 px-2 py-1 text-xs font-semibold leading-5 text-gray-800";
+
+  return <span className={className}>{label}</span>;
+}
+
+function CommentIndicator({ report }: { report: Report }) {
+  if (report.status === "draft") {
+    return <span className="text-gray-400">&mdash;</span>;
+  }
+
+  if (report.has_unread_comment) {
+    return (
+      <span className="flex items-center gap-1">
+        未コメント
+        <span className="text-red-500" aria-label="未読コメントあり">
+          ●
+        </span>
+      </span>
+    );
+  }
+
+  return <span>コメント済み</span>;
+}
+
+function formatDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split("-");
+  return `${year}/${month}/${day}`;
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback } from "react";
+import type { User } from "@/src/types";
+import { ROLE_LABELS } from "@/src/types";
+
+interface HeaderProps {
+  user: User;
+}
+
+export function Header({ user }: HeaderProps) {
+  const router = useRouter();
+
+  const handleLogout = useCallback(async () => {
+    try {
+      await fetch("/api/auth/logout", { method: "POST" });
+    } catch {
+      // Proceed to redirect even if the API call fails
+    }
+    router.push("/login");
+  }, [router]);
+
+  return (
+    <header className="border-b border-gray-200 bg-white shadow-sm">
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3 sm:px-6 lg:px-8">
+        <h1 className="text-lg font-bold text-gray-900">営業日報システム</h1>
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-gray-700">
+            {user.name}({ROLE_LABELS[user.role]})
+          </span>
+          <button
+            type="button"
+            onClick={handleLogout}
+            className="rounded-md px-3 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+          >
+            ログアウト
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,16 @@
+import type { User } from "@/src/types";
+
+/**
+ * Mock auth helper.
+ * Returns a stub user for development until the real auth system is implemented.
+ * Change the `role` field to test different role-based views.
+ */
+export function getCurrentUser(): User {
+  return {
+    id: 1,
+    name: "山田太郎",
+    email: "yamada@example.com",
+    role: "sales",
+    department: { id: 1, name: "東京営業部" },
+  };
+}

--- a/src/lib/mockData.ts
+++ b/src/lib/mockData.ts
@@ -1,0 +1,97 @@
+import type { Report, ReportUser, ReportsResponse } from "@/src/types";
+
+const users: ReportUser[] = [
+  { id: 1, name: "山田太郎" },
+  { id: 2, name: "鈴木花子" },
+];
+
+function generateReports(): Report[] {
+  const reports: Report[] = [];
+  let id = 1;
+
+  // Generate reports for April 2026
+  for (let day = 1; day <= 4; day++) {
+    const dateStr = `2026-04-${String(day).padStart(2, "0")}`;
+    for (const user of users) {
+      const isSubmitted = day <= 3;
+      reports.push({
+        id: id++,
+        report_date: dateStr,
+        status: isSubmitted ? "submitted" : "draft",
+        submitted_at: isSubmitted ? `${dateStr}T18:30:00+09:00` : null,
+        user,
+        has_unread_comment: isSubmitted && id % 3 === 0,
+        created_at: `${dateStr}T09:00:00+09:00`,
+        updated_at: `${dateStr}T18:30:00+09:00`,
+      });
+    }
+  }
+
+  // Generate reports for March 2026
+  for (let day = 1; day <= 31; day++) {
+    // Skip weekends (March 2026: 1=Sun, 7=Sat, 8=Sun, etc.)
+    const date = new Date(2026, 2, day);
+    if (date.getDay() === 0 || date.getDay() === 6) continue;
+
+    const dateStr = `2026-03-${String(day).padStart(2, "0")}`;
+    for (const user of users) {
+      reports.push({
+        id: id++,
+        report_date: dateStr,
+        status: "submitted",
+        submitted_at: `${dateStr}T18:30:00+09:00`,
+        user,
+        has_unread_comment: id % 5 === 0,
+        created_at: `${dateStr}T09:00:00+09:00`,
+        updated_at: `${dateStr}T18:30:00+09:00`,
+      });
+    }
+  }
+
+  return reports;
+}
+
+const allReports = generateReports();
+
+export function getReports(params: {
+  page?: number;
+  per_page?: number;
+  year_month?: string;
+  user_id?: number;
+  status?: string;
+}): ReportsResponse {
+  const { page = 1, per_page = 20, year_month, user_id, status } = params;
+
+  let filtered = allReports;
+
+  if (year_month) {
+    filtered = filtered.filter((r) => r.report_date.startsWith(year_month));
+  }
+
+  if (user_id) {
+    filtered = filtered.filter((r) => r.user.id === user_id);
+  }
+
+  if (status) {
+    filtered = filtered.filter((r) => r.status === status);
+  }
+
+  // Sort by date descending
+  filtered = [...filtered].sort(
+    (a, b) => new Date(b.report_date).getTime() - new Date(a.report_date).getTime(),
+  );
+
+  const total = filtered.length;
+  const start = (page - 1) * per_page;
+  const data = filtered.slice(start, start + per_page);
+
+  return {
+    data,
+    meta: { total, page, per_page },
+  };
+}
+
+/** List of users available for the user filter dropdown (manager/admin view) */
+export function getFilterUsers(): ReportUser[] {
+  return users;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,60 @@
+export type Role = "sales" | "manager" | "admin";
+
+export type ReportStatus = "draft" | "submitted";
+
+export interface Department {
+  id: number;
+  name: string;
+}
+
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+  role: Role;
+  department: Department;
+}
+
+export interface ReportUser {
+  id: number;
+  name: string;
+}
+
+export interface Report {
+  id: number;
+  report_date: string;
+  status: ReportStatus;
+  submitted_at: string | null;
+  user: ReportUser;
+  has_unread_comment: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PaginationMeta {
+  total: number;
+  page: number;
+  per_page: number;
+}
+
+export interface ReportsResponse {
+  data: Report[];
+  meta: PaginationMeta;
+}
+
+export interface RoleLabelMap {
+  sales: string;
+  manager: string;
+  admin: string;
+}
+
+export const ROLE_LABELS: RoleLabelMap = {
+  sales: "営業",
+  manager: "上長",
+  admin: "管理者",
+};
+
+export const STATUS_LABELS: Record<ReportStatus, string> = {
+  draft: "下書き",
+  submitted: "提出済み",
+};


### PR DESCRIPTION
## Summary
- SCR-02仕様に基づきダッシュボード（日報一覧）画面を実装
- ロール別表示制御（営業: 自分の日報のみ＋作成ボタン、上長/管理者: 全日報＋担当者フィルター）
- 年月・ステータス・営業担当フィルター、20件ページネーション対応
- 未コメントバッジ（●）表示、行クリックで日報詳細遷移、ログアウト機能
- モバイルレスポンシブ対応（横スクロール）

## Files
- `src/app/(app)/dashboard/page.tsx` - ダッシュボードページ（Server Component）
- `src/app/(app)/layout.tsx` - アプリルートグループレイアウト（ヘッダー含む）
- `src/components/dashboard/FilterBar.tsx` - フィルターバー（Client Component）
- `src/components/dashboard/ReportList.tsx` - 日報一覧テーブル（Client Component）
- `src/components/dashboard/Pagination.tsx` - ページネーション
- `src/components/layout/Header.tsx` - ヘッダー（ログアウト機能）
- `src/lib/auth.ts` - 認証スタブ（モックユーザー）
- `src/lib/mockData.ts` - モックデータ
- `src/types/index.ts` - 共通型定義

## Test plan
- [x] `npm run type-check` パス
- [x] `npm run lint` パス
- [x] `npm run test` パス
- [ ] `npm run dev` でダッシュボード画面が表示されること
- [ ] ロール変更（auth.ts）で表示制御が切り替わること
- [ ] フィルター操作でURLパラメータが更新されること

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)