### PR TITLE
feat: Issue #13 日報作成・編集画面を実装

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,0 +1,10 @@
+import { Header } from "@/src/components/layout/Header";
+
+export default function AppLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <Header />
+      <main className="mx-auto max-w-5xl px-4 py-6">{children}</main>
+    </>
+  );
+}

--- a/src/app/(app)/reports/[id]/edit/page.tsx
+++ b/src/app/(app)/reports/[id]/edit/page.tsx
@@ -1,0 +1,37 @@
+import { notFound } from "next/navigation";
+import { ReportForm } from "@/src/components/report/ReportForm";
+import { getCustomers, getReportById } from "@/src/lib/mockData";
+import type { ReportFormData } from "@/src/types";
+
+export const metadata = {
+  title: "日報編集 | 営業日報システム",
+};
+
+type EditReportPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function EditReportPage({ params }: EditReportPageProps) {
+  const { id } = await params;
+  const report = getReportById(id);
+
+  if (!report) {
+    notFound();
+  }
+
+  const customers = getCustomers();
+
+  const initialData: ReportFormData = {
+    report_date: report.report_date,
+    visit_records: report.visit_records.map((vr) => ({
+      id: vr.id,
+      customer_id: vr.customer.id,
+      content: vr.content,
+      visited_at: vr.visited_at,
+    })),
+    problem: report.problem,
+    plan: report.plan,
+  };
+
+  return <ReportForm mode="edit" customers={customers} initialData={initialData} reportId={id} />;
+}

--- a/src/app/(app)/reports/new/page.tsx
+++ b/src/app/(app)/reports/new/page.tsx
@@ -1,0 +1,12 @@
+import { ReportForm } from "@/src/components/report/ReportForm";
+import { getCustomers } from "@/src/lib/mockData";
+
+export const metadata = {
+  title: "日報作成 | 営業日報システム",
+};
+
+export default function NewReportPage() {
+  const customers = getCustomers();
+
+  return <ReportForm mode="new" customers={customers} />;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,14 @@
+import "@/src/app/globals.css";
+
+export const metadata = {
+  title: "営業日報システム",
+  description: "営業担当者向け日報管理システム",
+};
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja">
-      <body>{children}</body>
+      <body className="min-h-screen bg-gray-50 text-gray-900 antialiased">{children}</body>
     </html>
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,24 @@
+import { getCurrentUser } from "@/src/lib/auth";
+
+export function Header() {
+  const user = getCurrentUser();
+
+  return (
+    <header className="border-b border-gray-200 bg-white shadow-sm">
+      <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
+        <h1 className="text-lg font-bold text-gray-900">営業日報システム</h1>
+        <div className="flex items-center gap-4">
+          <span className="text-sm text-gray-600">
+            {user.department.name} / {user.name}
+          </span>
+          <button
+            type="button"
+            className="rounded-md bg-gray-100 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-200"
+          >
+            ログアウト
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/report/ReportForm.tsx
+++ b/src/components/report/ReportForm.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useRouter } from "next/navigation";
+import type { Customer, ReportFormData, VisitRecord } from "@/src/types";
+import { VisitRecordRow } from "@/src/components/report/VisitRecordRow";
+
+type ReportFormProps = {
+  mode: "new" | "edit";
+  customers: Customer[];
+  initialData?: ReportFormData;
+  reportId?: string;
+};
+
+function createEmptyVisitRecord(): VisitRecord {
+  return { customer_id: "", content: "", visited_at: "" };
+}
+
+function formatToday(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+type FieldErrors = Record<string, string>;
+type VisitRecordErrors = Record<number, { customer_id?: string; content?: string }>;
+
+export function ReportForm({ mode, customers, initialData, reportId }: ReportFormProps) {
+  const router = useRouter();
+
+  const [reportDate, setReportDate] = useState(initialData?.report_date ?? formatToday());
+  const [visitRecords, setVisitRecords] = useState<VisitRecord[]>(
+    initialData?.visit_records ?? [createEmptyVisitRecord()],
+  );
+  const [problem, setProblem] = useState(initialData?.problem ?? "");
+  const [plan, setPlan] = useState(initialData?.plan ?? "");
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [visitErrors, setVisitErrors] = useState<VisitRecordErrors>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleVisitChange = useCallback(
+    (index: number, field: keyof VisitRecord, value: string | number) => {
+      setVisitRecords((prev) => prev.map((r, i) => (i === index ? { ...r, [field]: value } : r)));
+    },
+    [],
+  );
+
+  const handleAddRow = useCallback(() => {
+    setVisitRecords((prev) => [...prev, createEmptyVisitRecord()]);
+  }, []);
+
+  const handleRemoveRow = useCallback((index: number) => {
+    setVisitRecords((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  function validate(): boolean {
+    const newErrors: FieldErrors = {};
+    const newVisitErrors: VisitRecordErrors = {};
+    let valid = true;
+
+    if (visitRecords.length === 0) {
+      newErrors.visitRecords = "訪問記録を1件以上入力してください。";
+      valid = false;
+    }
+
+    visitRecords.forEach((record, i) => {
+      const recErr: { customer_id?: string; content?: string } = {};
+      if (record.customer_id === "") {
+        recErr.customer_id = "顧客を選択してください。";
+        valid = false;
+      }
+      if (record.content.trim() === "") {
+        recErr.content = "訪問内容を入力してください。";
+        valid = false;
+      }
+      if (recErr.customer_id || recErr.content) {
+        newVisitErrors[i] = recErr;
+      }
+    });
+
+    if (problem.length > 2000) {
+      newErrors.problem = "2000文字以内で入力してください。";
+      valid = false;
+    }
+    if (plan.length > 2000) {
+      newErrors.plan = "2000文字以内で入力してください。";
+      valid = false;
+    }
+
+    setErrors(newErrors);
+    setVisitErrors(newVisitErrors);
+    return valid;
+  }
+
+  function buildPayload(status: "draft" | "submitted"): ReportFormData & { status: string } {
+    return {
+      report_date: reportDate,
+      visit_records: visitRecords,
+      problem,
+      plan,
+      status,
+    };
+  }
+
+  async function handleDraft() {
+    setIsSubmitting(true);
+    try {
+      const payload = buildPayload("draft");
+      // eslint-disable-next-line no-console
+      console.log(
+        mode === "edit" ? `PUT /api/v1/reports/${reportId}` : "POST /api/v1/reports",
+        payload,
+      );
+      router.push("/dashboard");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function handleSubmit() {
+    if (!validate()) return;
+
+    setIsSubmitting(true);
+    try {
+      const payload = buildPayload("submitted");
+      const mockId = reportId ?? "new-1";
+      // eslint-disable-next-line no-console
+      console.log(
+        mode === "edit" ? `PUT /api/v1/reports/${reportId}` : "POST /api/v1/reports",
+        payload,
+      );
+      router.push(`/reports/${mockId}`);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  const title = mode === "new" ? "日報作成" : "日報編集";
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        void handleSubmit();
+      }}
+      noValidate
+      aria-label={title}
+    >
+      {/* Header */}
+      <div className="mb-6 flex items-center justify-between">
+        <h2 className="text-xl font-bold text-gray-900">{title}</h2>
+        <div className="flex items-center gap-2">
+          <label htmlFor="report-date" className="text-sm font-medium text-gray-700">
+            日付
+          </label>
+          <input
+            id="report-date"
+            type="date"
+            value={reportDate}
+            onChange={(e) => setReportDate(e.target.value)}
+            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          />
+        </div>
+      </div>
+
+      {/* Visit Records Section */}
+      <section className="mb-6" aria-labelledby="visit-records-heading">
+        <h3 id="visit-records-heading" className="mb-3 text-base font-semibold text-gray-800">
+          訪問記録
+        </h3>
+        {errors.visitRecords && (
+          <p className="mb-2 text-sm text-red-600" role="alert">
+            {errors.visitRecords}
+          </p>
+        )}
+        <div className="flex flex-col gap-3">
+          {visitRecords.map((record, index) => (
+            <VisitRecordRow
+              key={record.id ?? index}
+              index={index}
+              record={record}
+              customers={customers}
+              onChange={handleVisitChange}
+              onRemove={handleRemoveRow}
+              canRemove={visitRecords.length > 1}
+              error={visitErrors[index]}
+            />
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={handleAddRow}
+          className="mt-3 rounded-md border border-dashed border-gray-400 px-4 py-2 text-sm text-gray-600 hover:border-blue-500 hover:text-blue-600"
+        >
+          + 行を追加
+        </button>
+      </section>
+
+      {/* Problem Section */}
+      <section className="mb-6">
+        <label htmlFor="problem" className="mb-1 block text-base font-semibold text-gray-800">
+          今の課題・相談
+        </label>
+        <textarea
+          id="problem"
+          value={problem}
+          onChange={(e) => setProblem(e.target.value)}
+          maxLength={2000}
+          rows={4}
+          className={`w-full rounded-md border px-3 py-2 text-sm ${
+            errors.problem ? "border-red-500" : "border-gray-300"
+          } focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none`}
+          placeholder="課題や相談事項を入力"
+        />
+        {errors.problem && (
+          <p className="mt-1 text-sm text-red-600" role="alert">
+            {errors.problem}
+          </p>
+        )}
+      </section>
+
+      {/* Plan Section */}
+      <section className="mb-6">
+        <label htmlFor="plan" className="mb-1 block text-base font-semibold text-gray-800">
+          明日やること
+        </label>
+        <textarea
+          id="plan"
+          value={plan}
+          onChange={(e) => setPlan(e.target.value)}
+          maxLength={2000}
+          rows={4}
+          className={`w-full rounded-md border px-3 py-2 text-sm ${
+            errors.plan ? "border-red-500" : "border-gray-300"
+          } focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none`}
+          placeholder="明日の予定・やることを入力"
+        />
+        {errors.plan && (
+          <p className="mt-1 text-sm text-red-600" role="alert">
+            {errors.plan}
+          </p>
+        )}
+      </section>
+
+      {/* Actions */}
+      <div className="flex items-center justify-end gap-3 border-t border-gray-200 pt-4">
+        <button
+          type="button"
+          onClick={() => void handleDraft()}
+          disabled={isSubmitting}
+          className="rounded-md border border-gray-300 bg-white px-5 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          下書き保存
+        </button>
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="rounded-md bg-blue-600 px-5 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          提出する
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/report/VisitRecordRow.tsx
+++ b/src/components/report/VisitRecordRow.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import type { Customer, VisitRecord } from "@/src/types";
+
+type VisitRecordRowProps = {
+  index: number;
+  record: VisitRecord;
+  customers: Customer[];
+  onChange: (index: number, field: keyof VisitRecord, value: string | number) => void;
+  onRemove: (index: number) => void;
+  canRemove: boolean;
+  error?: { customer_id?: string; content?: string };
+};
+
+export function VisitRecordRow({
+  index,
+  record,
+  customers,
+  onChange,
+  onRemove,
+  canRemove,
+  error,
+}: VisitRecordRowProps) {
+  return (
+    <div className="flex flex-col gap-2 rounded-md border border-gray-200 bg-white p-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+        {/* Customer select */}
+        <div className="flex flex-1 flex-col gap-1">
+          <label htmlFor={`customer-${index}`} className="text-sm font-medium text-gray-700">
+            顧客名
+          </label>
+          <select
+            id={`customer-${index}`}
+            value={record.customer_id}
+            onChange={(e) => {
+              const val = e.target.value;
+              onChange(index, "customer_id", val === "" ? "" : Number(val));
+            }}
+            className={`rounded-md border px-3 py-2 text-sm ${
+              error?.customer_id ? "border-red-500" : "border-gray-300"
+            } focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none`}
+          >
+            <option value="">顧客を選択</option>
+            {customers.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.company_name} - {c.name}
+              </option>
+            ))}
+          </select>
+          {error?.customer_id && (
+            <p className="text-sm text-red-600" role="alert">
+              {error.customer_id}
+            </p>
+          )}
+        </div>
+
+        {/* Content textarea */}
+        <div className="flex flex-[2] flex-col gap-1">
+          <label htmlFor={`content-${index}`} className="text-sm font-medium text-gray-700">
+            訪問内容
+          </label>
+          <textarea
+            id={`content-${index}`}
+            value={record.content}
+            onChange={(e) => onChange(index, "content", e.target.value)}
+            maxLength={1000}
+            rows={2}
+            className={`rounded-md border px-3 py-2 text-sm ${
+              error?.content ? "border-red-500" : "border-gray-300"
+            } focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none`}
+            placeholder="訪問内容を入力"
+          />
+          {error?.content && (
+            <p className="text-sm text-red-600" role="alert">
+              {error.content}
+            </p>
+          )}
+        </div>
+
+        {/* Time input */}
+        <div className="flex flex-col gap-1">
+          <label htmlFor={`time-${index}`} className="text-sm font-medium text-gray-700">
+            訪問時刻
+          </label>
+          <input
+            id={`time-${index}`}
+            type="time"
+            value={record.visited_at}
+            onChange={(e) => onChange(index, "visited_at", e.target.value)}
+            className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          />
+        </div>
+
+        {/* Remove button */}
+        <div className="flex flex-col justify-end">
+          <span className="text-sm font-medium text-transparent sm:block">削除</span>
+          <button
+            type="button"
+            onClick={() => onRemove(index)}
+            disabled={!canRemove}
+            aria-label={`訪問記録 ${index + 1} を削除`}
+            className="rounded-md border border-gray-300 px-3 py-2 text-sm text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:text-gray-300 disabled:hover:bg-transparent"
+          >
+            &times;
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,12 @@
+import type { User } from "@/src/types";
+
+/** Mock auth stub — returns a hardcoded sales user */
+export function getCurrentUser(): User {
+  return {
+    id: 1,
+    name: "山田太郎",
+    email: "yamada@example.com",
+    role: "sales",
+    department: { id: 1, name: "東京営業部" },
+  };
+}

--- a/src/lib/mockData.ts
+++ b/src/lib/mockData.ts
@@ -1,0 +1,44 @@
+import type { Customer, Report } from "@/src/types";
+
+export function getCustomers(): Customer[] {
+  return [
+    { id: 1, name: "田中一郎", company_name: "株式会社アルファ" },
+    { id: 2, name: "佐藤花子", company_name: "株式会社ベータ" },
+    { id: 3, name: "鈴木次郎", company_name: "ガンマ工業株式会社" },
+    { id: 4, name: "高橋美咲", company_name: "デルタ商事株式会社" },
+    { id: 5, name: "伊藤健太", company_name: "イプシロン技研株式会社" },
+    { id: 6, name: "渡辺由美", company_name: "ゼータソリューションズ株式会社" },
+  ];
+}
+
+export function getReportById(id: string): Report | null {
+  if (id === "1") {
+    return {
+      id: 1,
+      report_date: "2026-04-03",
+      status: "draft",
+      submitted_at: null,
+      user: { id: 1, name: "山田太郎" },
+      visit_records: [
+        {
+          id: 101,
+          customer: { id: 1, name: "田中一郎", company_name: "株式会社アルファ" },
+          content: "新製品の提案を行い、サンプル品の送付を約束した。",
+          visited_at: "10:00",
+        },
+        {
+          id: 102,
+          customer: { id: 3, name: "鈴木次郎", company_name: "ガンマ工業株式会社" },
+          content: "既存契約の更新について打ち合わせ。来月中に回答予定。",
+          visited_at: "14:30",
+        },
+      ],
+      problem: "ガンマ工業の契約更新について、価格面での調整が必要。",
+      plan: "アルファ社へサンプル品を発送。ガンマ工業向けの見積書を作成。",
+      has_unread_comment: false,
+      created_at: "2026-04-03T09:00:00+09:00",
+      updated_at: "2026-04-03T17:00:00+09:00",
+    };
+  }
+  return null;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,48 @@
+export type Role = "sales" | "manager" | "admin";
+
+export type User = {
+  id: number;
+  name: string;
+  email: string;
+  role: Role;
+  department: { id: number; name: string };
+};
+
+export type Customer = {
+  id: number;
+  name: string;
+  company_name: string;
+};
+
+export type VisitRecord = {
+  id?: number;
+  customer_id: number | "";
+  content: string;
+  visited_at: string;
+};
+
+export type ReportFormData = {
+  report_date: string;
+  visit_records: VisitRecord[];
+  problem: string;
+  plan: string;
+};
+
+export type Report = {
+  id: number;
+  report_date: string;
+  status: "draft" | "submitted";
+  submitted_at: string | null;
+  user: { id: number; name: string };
+  visit_records: Array<{
+    id: number;
+    customer: Customer;
+    content: string;
+    visited_at: string;
+  }>;
+  problem: string;
+  plan: string;
+  has_unread_comment: boolean;
+  created_at: string;
+  updated_at: string;
+};


### PR DESCRIPTION
## Summary
- SCR-03仕様に基づき日報作成・編集画面を実装
- 訪問記録の動的行追加・削除（ST-F-002対応）
- 顧客プルダウン（モックデータ）による顧客選択
- 提出時バリデーション（訪問記録1行以上、顧客名・訪問内容必須）
- 下書き保存・提出の2アクション対応
- 新規作成と編集を共通ReportFormコンポーネントで実現（ST-F-004対応）
- モバイルレスポンシブ対応

## Files
- `src/app/(app)/reports/new/page.tsx` — 新規作成ページ
- `src/app/(app)/reports/[id]/edit/page.tsx` — 編集ページ
- `src/components/report/ReportForm.tsx` — フォームコンポーネント（共用）
- `src/components/report/VisitRecordRow.tsx` — 訪問記録1行コンポーネント
- `src/app/(app)/layout.tsx` — アプリレイアウト（ヘッダー付き）
- `src/components/layout/Header.tsx` — ヘッダー
- `src/lib/auth.ts` — 認証モックスタブ
- `src/lib/mockData.ts` — モックデータ（顧客・日報）
- `src/types/index.ts` — 共通型定義
- `src/app/globals.css` — Tailwind CSS

## Test plan
- [x] `npm run type-check` パス
- [x] `npm run lint` パス
- [x] `npm run test` パス
- [ ] 新規作成画面で訪問記録の行追加・削除が動作すること
- [ ] 顧客プルダウンに顧客マスタが表示されること
- [ ] 提出時バリデーションエラーが表示されること
- [ ] 編集画面で既存データが初期表示されること

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)