### PR TITLE
feat: Issue #14 日報詳細画面（SCR-04）を実装

### DIFF
--- a/src/app/(app)/reports/[id]/page.tsx
+++ b/src/app/(app)/reports/[id]/page.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useAuth } from "@/src/lib/auth";
+import { CommentSection } from "@/src/components/report/CommentSection";
+import type { Report, Comment } from "@/src/types/report";
+
+export default function ReportDetailPage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const { user } = useAuth();
+
+  const [report, setReport] = useState<Report | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchReport() {
+      try {
+        const res = await fetch(`/api/v1/reports/${params.id}`);
+        if (!res.ok) {
+          throw new Error("日報の取得に失敗しました。");
+        }
+        const json = (await res.json()) as { data: Report };
+        setReport(json.data);
+      } catch {
+        setError("日報の取得に失敗しました。再度お試しください。");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchReport();
+  }, [params.id]);
+
+  const handleCommentAdded = useCallback((newComment: Comment) => {
+    setReport((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        comments: [...prev.comments, newComment],
+      };
+    });
+  }, []);
+
+  const canComment = user.role === "manager";
+  const canEdit =
+    report !== null &&
+    report.status === "draft" &&
+    user.role === "sales" &&
+    user.id === report.user.id;
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-gray-500">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (error || !report) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="text-center">
+          <p className="text-red-600">{error ?? "日報が見つかりません。"}</p>
+          <button
+            onClick={() => router.push("/reports")}
+            className="mt-4 text-sm text-blue-600 hover:underline"
+          >
+            一覧へ戻る
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl px-4 py-6">
+      {/* Header */}
+      <div className="mb-6 flex items-center justify-between">
+        <button
+          onClick={() => router.push("/reports")}
+          className="flex items-center gap-1 text-sm text-blue-600 hover:underline"
+          aria-label="日報一覧へ戻る"
+        >
+          <span aria-hidden="true">&larr;</span> 一覧へ
+        </button>
+        <h1 className="text-lg font-bold text-gray-900">日報詳細</h1>
+        <span className="text-sm text-gray-500">
+          {report.user.name} / {report.report_date}
+        </span>
+      </div>
+
+      {/* 訪問記録 */}
+      <section aria-labelledby="visit-records-heading" className="mb-8">
+        <h2 id="visit-records-heading" className="mb-3 text-base font-semibold text-gray-800">
+          訪問記録
+        </h2>
+        {report.visit_records.length === 0 ? (
+          <p className="text-sm text-gray-400">訪問記録なし</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-gray-200 text-left text-gray-600">
+                  <th className="px-3 py-2 font-medium" scope="col">
+                    顧客名
+                  </th>
+                  <th className="px-3 py-2 font-medium" scope="col">
+                    訪問内容
+                  </th>
+                  <th className="px-3 py-2 font-medium" scope="col">
+                    時刻
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {report.visit_records.map((record) => (
+                  <tr key={record.id} className="border-b border-gray-100 hover:bg-gray-50">
+                    <td className="px-3 py-2 whitespace-nowrap">{record.customer.company_name}</td>
+                    <td className="px-3 py-2">{record.content}</td>
+                    <td className="px-3 py-2 whitespace-nowrap">{record.visited_at}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* 課題・相談 (problem) */}
+      <section aria-labelledby="problem-heading" className="mb-8">
+        <h2 id="problem-heading" className="mb-3 text-base font-semibold text-gray-800">
+          今の課題・相談
+        </h2>
+        <div className="rounded border border-gray-200 bg-white px-4 py-3">
+          <p className="text-sm whitespace-pre-wrap text-gray-800">
+            {report.problem || "記載なし"}
+          </p>
+        </div>
+        <CommentSection
+          reportId={report.id}
+          targetType="problem"
+          comments={report.comments}
+          canComment={canComment}
+          onCommentAdded={handleCommentAdded}
+        />
+      </section>
+
+      {/* 明日やること (plan) */}
+      <section aria-labelledby="plan-heading" className="mb-8">
+        <h2 id="plan-heading" className="mb-3 text-base font-semibold text-gray-800">
+          明日やること
+        </h2>
+        <div className="rounded border border-gray-200 bg-white px-4 py-3">
+          <p className="text-sm whitespace-pre-wrap text-gray-800">{report.plan || "記載なし"}</p>
+        </div>
+        <CommentSection
+          reportId={report.id}
+          targetType="plan"
+          comments={report.comments}
+          canComment={canComment}
+          onCommentAdded={handleCommentAdded}
+        />
+      </section>
+
+      {/* 編集ボタン */}
+      {canEdit && (
+        <div className="flex justify-end">
+          <button
+            onClick={() => router.push(`/reports/${report.id}/edit`)}
+            className="rounded bg-gray-800 px-6 py-2 text-sm font-medium text-white hover:bg-gray-900"
+          >
+            編集する
+          </button>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/src/components/report/CommentSection.tsx
+++ b/src/components/report/CommentSection.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import type { Comment } from "@/src/types/report";
+
+function formatDateTime(isoString: string): string {
+  const date = new Date(isoString);
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${month}/${day} ${hours}:${minutes}`;
+}
+
+interface CommentSectionProps {
+  reportId: number;
+  targetType: "problem" | "plan";
+  comments: Comment[];
+  canComment: boolean;
+  onCommentAdded: (comment: Comment) => void;
+}
+
+const MAX_COMMENT_LENGTH = 1000;
+
+export function CommentSection({
+  reportId,
+  targetType,
+  comments,
+  canComment,
+  onCommentAdded,
+}: CommentSectionProps) {
+  const [content, setContent] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const filteredComments = comments.filter((c) => c.target_type === targetType);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    const trimmed = content.trim();
+    if (!trimmed) return;
+
+    if (trimmed.length > MAX_COMMENT_LENGTH) {
+      setError(`コメントは${MAX_COMMENT_LENGTH}文字以内で入力してください。`);
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/v1/reports/${reportId}/comments`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ target_type: targetType, content: trimmed }),
+      });
+
+      if (!res.ok) {
+        throw new Error("コメントの投稿に失敗しました。");
+      }
+
+      const json = (await res.json()) as { data: Comment };
+      onCommentAdded(json.data);
+      setContent("");
+    } catch {
+      setError("コメントの投稿に失敗しました。再度お試しください。");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="mt-3">
+      <h4 className="mb-2 text-sm font-medium text-gray-600">コメント</h4>
+
+      {filteredComments.length === 0 ? (
+        <p className="text-sm text-gray-400">コメントなし</p>
+      ) : (
+        <ul className="space-y-2">
+          {filteredComments.map((comment) => (
+            <li key={comment.id} className="rounded border border-gray-100 bg-gray-50 px-3 py-2">
+              <div className="flex items-center gap-2 text-xs text-gray-500">
+                <span className="font-medium text-gray-700">{comment.user.name}</span>
+                <time dateTime={comment.created_at}>{formatDateTime(comment.created_at)}</time>
+              </div>
+              <p className="mt-1 text-sm whitespace-pre-wrap text-gray-800">{comment.content}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {canComment && (
+        <form onSubmit={handleSubmit} className="mt-3">
+          <label htmlFor={`comment-${targetType}`} className="sr-only">
+            {targetType === "problem" ? "課題へのコメント" : "計画へのコメント"}
+          </label>
+          <textarea
+            id={`comment-${targetType}`}
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder="コメントを入力..."
+            maxLength={MAX_COMMENT_LENGTH}
+            rows={2}
+            className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+            aria-describedby={error ? `comment-error-${targetType}` : undefined}
+          />
+          <div className="mt-1 flex items-center justify-between">
+            <div>
+              {error && (
+                <p id={`comment-error-${targetType}`} className="text-sm text-red-600" role="alert">
+                  {error}
+                </p>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-gray-400">
+                {content.length}/{MAX_COMMENT_LENGTH}
+              </span>
+              <button
+                type="submit"
+                disabled={isSubmitting || content.trim().length === 0}
+                className="rounded bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isSubmitting ? "送信中..." : "送信"}
+              </button>
+            </div>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,21 @@
+import type { Role } from "@/src/types/report";
+
+export interface AuthUser {
+  id: number;
+  name: string;
+  role: Role;
+}
+
+/**
+ * 現在のログインユーザーを返すスタブ。
+ * 認証基盤が整備されたら実装を差し替える。
+ */
+export function useAuth(): { user: AuthUser } {
+  return {
+    user: {
+      id: 2,
+      name: "田中部長",
+      role: "manager",
+    },
+  };
+}

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -1,0 +1,62 @@
+export type Role = "sales" | "manager" | "admin";
+
+export interface Department {
+  id: number;
+  name: string;
+}
+
+export interface User {
+  id: number;
+  name: string;
+  department?: Department;
+}
+
+export interface Customer {
+  id: number;
+  name: string;
+  company_name: string;
+}
+
+export interface VisitRecord {
+  id: number;
+  customer: Customer;
+  content: string;
+  visited_at: string;
+}
+
+export interface Comment {
+  id: number;
+  target_type: "problem" | "plan";
+  content: string;
+  user: User;
+  created_at: string;
+}
+
+export type ReportStatus = "draft" | "submitted";
+
+export interface Report {
+  id: number;
+  report_date: string;
+  status: ReportStatus;
+  submitted_at: string | null;
+  user: User;
+  visit_records: VisitRecord[];
+  problem: string;
+  plan: string;
+  comments: Comment[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ReportDetailResponse {
+  data: Report;
+}
+
+export interface CommentCreateRequest {
+  target_type: "problem" | "plan";
+  content: string;
+}
+
+export interface CommentCreateResponse {
+  data: Comment & { report_id: number };
+}


### PR DESCRIPTION
## Summary
- 日報詳細画面（SCR-04）を新規実装
- 訪問記録・課題(problem)・計画(plan)の表示と、セクション別コメント表示
- 上長(manager)のみコメント投稿可能（1000文字制限、楽観的UI更新）
- ロール別表示制御: 編集ボタンは営業本人＋下書き時のみ、コメント欄はmanagerのみ

## Files
- `src/app/(app)/reports/[id]/page.tsx` — 日報詳細ページ
- `src/components/report/CommentSection.tsx` — コメント表示・投稿コンポーネント
- `src/types/report.ts` — API型定義
- `src/lib/auth.ts` — 認証スタブ（useAuth hook）

## Test plan
- [ ] 訪問記録・problem・plan・コメントが表示されること
- [ ] problemとplanのコメントが正しい位置に表示されること
- [ ] managerのみコメント入力欄が表示されること
- [ ] コメント投稿後に画面が更新されること（UAT-003）
- [ ] 提出済み日報で「編集する」ボタンが表示されないこと（ST-F-004）
- [ ] 下書き日報で営業本人に「編集する」ボタンが表示されること

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)