### PR TITLE
feat: Issue #15 顧客マスタ一覧・登録・編集画面を実装

### DIFF
--- a/src/app/(app)/customers/CustomerSearchBar.tsx
+++ b/src/app/(app)/customers/CustomerSearchBar.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+
+type CustomerSearchBarProps = {
+  defaultValue?: string;
+};
+
+export function CustomerSearchBar({ defaultValue }: CustomerSearchBarProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [keyword, setKeyword] = useState(defaultValue ?? "");
+
+  function handleSearch(e: React.FormEvent) {
+    e.preventDefault();
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (keyword.trim()) {
+      params.set("q", keyword.trim());
+    } else {
+      params.delete("q");
+    }
+    params.delete("page");
+
+    router.push(`/customers?${params.toString()}`);
+  }
+
+  return (
+    <form onSubmit={handleSearch} className="flex gap-2">
+      <label htmlFor="customer-search" className="sr-only">
+        検索キーワード
+      </label>
+      <input
+        id="customer-search"
+        type="text"
+        value={keyword}
+        onChange={(e) => setKeyword(e.target.value)}
+        placeholder="検索キーワード"
+        className="block w-full max-w-md rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+      />
+      <button
+        type="submit"
+        className="rounded-md bg-gray-600 px-4 py-2 text-sm font-medium text-white hover:bg-gray-700 focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 focus:outline-none"
+      >
+        検索
+      </button>
+    </form>
+  );
+}

--- a/src/app/(app)/customers/[id]/edit/page.tsx
+++ b/src/app/(app)/customers/[id]/edit/page.tsx
@@ -1,0 +1,30 @@
+import { notFound } from "next/navigation";
+import { CustomerForm } from "@/src/components/customer/CustomerForm";
+import { getCustomerById } from "@/src/lib/mockData";
+
+type PageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function EditCustomerPage({ params }: PageProps) {
+  const { id } = await params;
+  const customer = getCustomerById(id);
+
+  if (!customer) {
+    notFound();
+  }
+
+  return (
+    <CustomerForm
+      mode="edit"
+      customerId={id}
+      initialData={{
+        name: customer.name,
+        company_name: customer.company_name,
+        phone: customer.phone,
+        email: customer.email,
+        address: customer.address,
+      }}
+    />
+  );
+}

--- a/src/app/(app)/customers/new/page.tsx
+++ b/src/app/(app)/customers/new/page.tsx
@@ -1,0 +1,5 @@
+import { CustomerForm } from "@/src/components/customer/CustomerForm";
+
+export default function NewCustomerPage() {
+  return <CustomerForm mode="new" />;
+}

--- a/src/app/(app)/customers/page.tsx
+++ b/src/app/(app)/customers/page.tsx
@@ -1,0 +1,144 @@
+import { Suspense } from "react";
+import Link from "next/link";
+import { getCurrentUser } from "@/src/lib/auth";
+import { getCustomers } from "@/src/lib/mockData";
+import { CustomerSearchBar } from "./CustomerSearchBar";
+
+type PageProps = {
+  searchParams: Promise<{ q?: string; page?: string }>;
+};
+
+export default async function CustomersPage({ searchParams }: PageProps) {
+  const { q, page: pageStr } = await searchParams;
+  const user = getCurrentUser();
+  const canEdit = user.role === "manager" || user.role === "admin";
+
+  const page = pageStr ? Number(pageStr) : 1;
+  const { data: customers, meta } = getCustomers({ q, page });
+
+  const totalPages = Math.ceil(meta.total / meta.per_page);
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <h2 className="text-2xl font-bold text-gray-900">顧客マスタ</h2>
+        {canEdit && (
+          <Link
+            href="/customers/new"
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none"
+          >
+            + 顧客を追加
+          </Link>
+        )}
+      </div>
+
+      <Suspense fallback={<div className="h-10" />}>
+        <CustomerSearchBar defaultValue={q} />
+      </Suspense>
+
+      <div className="mt-4 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th
+                scope="col"
+                className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase"
+              >
+                顧客名
+              </th>
+              <th
+                scope="col"
+                className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase"
+              >
+                会社名
+              </th>
+              <th
+                scope="col"
+                className="px-6 py-3 text-left text-xs font-medium tracking-wider text-gray-500 uppercase"
+              >
+                電話番号
+              </th>
+              {canEdit && (
+                <th
+                  scope="col"
+                  className="px-6 py-3 text-right text-xs font-medium tracking-wider text-gray-500 uppercase"
+                >
+                  操作
+                </th>
+              )}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 bg-white">
+            {customers.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={canEdit ? 4 : 3}
+                  className="px-6 py-8 text-center text-sm text-gray-500"
+                >
+                  顧客が見つかりませんでした
+                </td>
+              </tr>
+            ) : (
+              customers.map((customer) => (
+                <tr key={customer.id} className="hover:bg-gray-50">
+                  <td className="px-6 py-4 text-sm font-medium whitespace-nowrap text-gray-900">
+                    {customer.name}
+                  </td>
+                  <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-500">
+                    {customer.company_name}
+                  </td>
+                  <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-500">
+                    {customer.phone}
+                  </td>
+                  {canEdit && (
+                    <td className="px-6 py-4 text-right text-sm whitespace-nowrap">
+                      <Link
+                        href={`/customers/${customer.id}/edit`}
+                        className="font-medium text-blue-600 hover:text-blue-800"
+                      >
+                        編集
+                      </Link>
+                    </td>
+                  )}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {totalPages > 1 && (
+        <nav aria-label="ページネーション" className="mt-4 flex items-center justify-between">
+          <p className="text-sm text-gray-700">
+            全 {meta.total} 件中 {(page - 1) * meta.per_page + 1} -{" "}
+            {Math.min(page * meta.per_page, meta.total)} 件を表示
+          </p>
+          <div className="flex gap-2">
+            {page > 1 && (
+              <Link
+                href={{
+                  pathname: "/customers",
+                  query: { ...(q ? { q } : {}), page: String(page - 1) },
+                }}
+                className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                前へ
+              </Link>
+            )}
+            {page < totalPages && (
+              <Link
+                href={{
+                  pathname: "/customers",
+                  query: { ...(q ? { q } : {}), page: String(page + 1) },
+                }}
+                className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                次へ
+              </Link>
+            )}
+          </div>
+        </nav>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,0 +1,13 @@
+import { Header } from "@/src/components/layout/Header";
+import { getCurrentUser } from "@/src/lib/auth";
+
+export default function AppLayout({ children }: { children: React.ReactNode }) {
+  const user = getCurrentUser();
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Header user={user} />
+      <main className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">{children}</main>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,5 @@
+import "@/src/app/globals.css";
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja">

--- a/src/components/customer/CustomerForm.tsx
+++ b/src/components/customer/CustomerForm.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import type { CustomerFormData } from "@/src/types";
+
+type ValidationErrors = Partial<Record<keyof CustomerFormData, string>>;
+
+type CustomerFormProps = {
+  mode: "new" | "edit";
+  initialData?: CustomerFormData;
+  customerId?: string;
+};
+
+function validate(data: CustomerFormData): ValidationErrors {
+  const errors: ValidationErrors = {};
+
+  if (!data.name.trim()) {
+    errors.name = "顧客名は必須です";
+  } else if (data.name.length > 100) {
+    errors.name = "顧客名は100文字以内で入力してください";
+  }
+
+  if (!data.company_name.trim()) {
+    errors.company_name = "会社名は必須です";
+  } else if (data.company_name.length > 200) {
+    errors.company_name = "会社名は200文字以内で入力してください";
+  }
+
+  if (data.phone && !/^[\d-]+$/.test(data.phone)) {
+    errors.phone = "電話番号は数字とハイフンのみ入力できます";
+  }
+
+  if (data.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
+    errors.email = "正しいメールアドレス形式で入力してください";
+  }
+
+  if (data.address && data.address.length > 500) {
+    errors.address = "住所は500文字以内で入力してください";
+  }
+
+  return errors;
+}
+
+const emptyFormData: CustomerFormData = {
+  name: "",
+  company_name: "",
+  phone: "",
+  email: "",
+  address: "",
+};
+
+export function CustomerForm({ mode, initialData, customerId }: CustomerFormProps) {
+  const router = useRouter();
+  const [formData, setFormData] = useState<CustomerFormData>(initialData ?? emptyFormData);
+  const [errors, setErrors] = useState<ValidationErrors>({});
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const validationErrors = validate(formData);
+
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    setErrors({});
+
+    const payload = mode === "edit" ? { id: customerId, ...formData } : formData;
+
+    // eslint-disable-next-line no-console
+    console.log(`[${mode === "new" ? "CREATE" : "UPDATE"}] Customer payload:`, payload);
+
+    router.push("/customers");
+  }
+
+  function handleCancel() {
+    router.push("/customers");
+  }
+
+  const title = mode === "new" ? "顧客を追加" : "顧客を編集";
+
+  return (
+    <div>
+      <h2 className="mb-6 text-2xl font-bold text-gray-900">{title}</h2>
+      <form onSubmit={handleSubmit} noValidate className="space-y-6">
+        <div>
+          <label htmlFor="name" className="mb-1 block text-sm font-medium text-gray-700">
+            顧客名 <span className="text-red-500">*</span>
+          </label>
+          <input
+            id="name"
+            name="name"
+            type="text"
+            value={formData.name}
+            onChange={handleChange}
+            maxLength={100}
+            className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          />
+          {errors.name && <p className="mt-1 text-sm text-red-600">{errors.name}</p>}
+        </div>
+
+        <div>
+          <label htmlFor="company_name" className="mb-1 block text-sm font-medium text-gray-700">
+            会社名 <span className="text-red-500">*</span>
+          </label>
+          <input
+            id="company_name"
+            name="company_name"
+            type="text"
+            value={formData.company_name}
+            onChange={handleChange}
+            maxLength={200}
+            className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          />
+          {errors.company_name && (
+            <p className="mt-1 text-sm text-red-600">{errors.company_name}</p>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="phone" className="mb-1 block text-sm font-medium text-gray-700">
+            電話番号
+          </label>
+          <input
+            id="phone"
+            name="phone"
+            type="tel"
+            value={formData.phone}
+            onChange={handleChange}
+            className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          />
+          {errors.phone && <p className="mt-1 text-sm text-red-600">{errors.phone}</p>}
+        </div>
+
+        <div>
+          <label htmlFor="email" className="mb-1 block text-sm font-medium text-gray-700">
+            メールアドレス
+          </label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            value={formData.email}
+            onChange={handleChange}
+            className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          />
+          {errors.email && <p className="mt-1 text-sm text-red-600">{errors.email}</p>}
+        </div>
+
+        <div>
+          <label htmlFor="address" className="mb-1 block text-sm font-medium text-gray-700">
+            住所
+          </label>
+          <textarea
+            id="address"
+            name="address"
+            value={formData.address}
+            onChange={handleChange}
+            maxLength={500}
+            rows={3}
+            className="block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          />
+          {errors.address && <p className="mt-1 text-sm text-red-600">{errors.address}</p>}
+        </div>
+
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none"
+          >
+            保存
+          </button>
+          <button
+            type="button"
+            onClick={handleCancel}
+            className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none"
+          >
+            キャンセル
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,26 @@
+import type { User } from "@/src/types";
+
+type HeaderProps = {
+  user: User;
+};
+
+export function Header({ user }: HeaderProps) {
+  return (
+    <header className="border-b border-gray-200 bg-white">
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3 sm:px-6 lg:px-8">
+        <h1 className="text-lg font-bold text-gray-900">営業日報システム</h1>
+        <div className="flex items-center gap-4">
+          <span className="text-sm text-gray-600">
+            {user.department.name} / {user.name}
+          </span>
+          <button
+            type="button"
+            className="rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-200"
+          >
+            ログアウト
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,12 @@
+import type { User } from "@/src/types";
+
+/** モック認証: 現在ログイン中のユーザーを返す */
+export function getCurrentUser(): User {
+  return {
+    id: 1,
+    name: "佐藤 管理太郎",
+    email: "sato@example.com",
+    role: "manager",
+    department: { id: 1, name: "東京営業部" },
+  };
+}

--- a/src/lib/mockData.ts
+++ b/src/lib/mockData.ts
@@ -1,0 +1,126 @@
+import type { Customer, PaginationMeta } from "@/src/types";
+
+const customers: Customer[] = [
+  {
+    id: 1,
+    name: "山田 一郎",
+    company_name: "株式会社ABC",
+    phone: "03-1234-5678",
+    email: "yamada@abc.co.jp",
+    address: "東京都千代田区丸の内1-1-1",
+    created_at: "2026-01-15T09:00:00+09:00",
+  },
+  {
+    id: 2,
+    name: "鈴木 次郎",
+    company_name: "有限会社XYZ",
+    phone: "06-9876-5432",
+    email: "suzuki@xyz.co.jp",
+    address: "大阪府大阪市北区梅田2-2-2",
+    created_at: "2026-01-20T10:30:00+09:00",
+  },
+  {
+    id: 3,
+    name: "佐藤 三郎",
+    company_name: "株式会社テクノ",
+    phone: "052-111-2222",
+    email: "sato@techno.co.jp",
+    address: "愛知県名古屋市中区栄3-3-3",
+    created_at: "2026-02-01T11:00:00+09:00",
+  },
+  {
+    id: 4,
+    name: "田中 花子",
+    company_name: "合同会社グリーン",
+    phone: "011-333-4444",
+    email: "tanaka@green.co.jp",
+    address: "北海道札幌市中央区北1条4-4-4",
+    created_at: "2026-02-10T13:00:00+09:00",
+  },
+  {
+    id: 5,
+    name: "高橋 五郎",
+    company_name: "株式会社マリン",
+    phone: "092-555-6666",
+    email: "takahashi@marine.co.jp",
+    address: "福岡県福岡市博多区5-5-5",
+    created_at: "2026-02-15T14:00:00+09:00",
+  },
+  {
+    id: 6,
+    name: "伊藤 六助",
+    company_name: "有限会社サンライズ",
+    phone: "022-777-8888",
+    email: "ito@sunrise.co.jp",
+    address: "宮城県仙台市青葉区6-6-6",
+    created_at: "2026-03-01T09:30:00+09:00",
+  },
+  {
+    id: 7,
+    name: "渡辺 七美",
+    company_name: "株式会社フューチャー",
+    phone: "045-999-0000",
+    email: "watanabe@future.co.jp",
+    address: "神奈川県横浜市西区7-7-7",
+    created_at: "2026-03-05T10:00:00+09:00",
+  },
+  {
+    id: 8,
+    name: "中村 八郎",
+    company_name: "合同会社ウインド",
+    phone: "075-222-3333",
+    email: "nakamura@wind.co.jp",
+    address: "京都府京都市中京区8-8-8",
+    created_at: "2026-03-10T11:30:00+09:00",
+  },
+  {
+    id: 9,
+    name: "小林 九太",
+    company_name: "株式会社スカイ",
+    phone: "048-444-5555",
+    email: "kobayashi@sky.co.jp",
+    address: "埼玉県さいたま市大宮区9-9-9",
+    created_at: "2026-03-15T08:00:00+09:00",
+  },
+  {
+    id: 10,
+    name: "加藤 十蔵",
+    company_name: "有限会社リバー",
+    phone: "082-666-7777",
+    email: "kato@river.co.jp",
+    address: "広島県広島市中区10-10-10",
+    created_at: "2026-03-20T15:00:00+09:00",
+  },
+];
+
+const PER_PAGE = 50;
+
+export function getCustomers(params?: { q?: string; page?: number }): {
+  data: Customer[];
+  meta: PaginationMeta;
+} {
+  const q = params?.q?.toLowerCase() ?? "";
+  const page = params?.page ?? 1;
+
+  const filtered = q
+    ? customers.filter(
+        (c) => c.name.toLowerCase().includes(q) || c.company_name.toLowerCase().includes(q),
+      )
+    : customers;
+
+  const start = (page - 1) * PER_PAGE;
+  const paginated = filtered.slice(start, start + PER_PAGE);
+
+  return {
+    data: paginated,
+    meta: {
+      total: filtered.length,
+      page,
+      per_page: PER_PAGE,
+    },
+  };
+}
+
+export function getCustomerById(id: string): Customer | undefined {
+  return customers.find((c) => c.id === Number(id));
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,33 @@
+export type Role = "sales" | "manager" | "admin";
+
+export type User = {
+  id: number;
+  name: string;
+  email: string;
+  role: Role;
+  department: { id: number; name: string };
+};
+
+export type Customer = {
+  id: number;
+  name: string;
+  company_name: string;
+  phone: string;
+  email: string;
+  address: string;
+  created_at: string;
+};
+
+export type CustomerFormData = {
+  name: string;
+  company_name: string;
+  phone: string;
+  email: string;
+  address: string;
+};
+
+export type PaginationMeta = {
+  total: number;
+  page: number;
+  per_page: number;
+};


### PR DESCRIPTION
## Summary
- SCR-05: 顧客マスタ一覧画面（キーワード検索、ページネーション、ロール別表示制御）
- SCR-06: 顧客マスタ登録・編集フォーム（バリデーション、新規・編集共用コンポーネント）
- 営業ロールでは追加・編集ボタン非表示、上長・管理者は全操作可能

## Files
- `src/app/(app)/customers/page.tsx` — 顧客一覧ページ（Server Component）
- `src/app/(app)/customers/CustomerSearchBar.tsx` — 検索バー（Client Component）
- `src/app/(app)/customers/new/page.tsx` — 新規登録ページ
- `src/app/(app)/customers/[id]/edit/page.tsx` — 編集ページ
- `src/components/customer/CustomerForm.tsx` — フォームコンポーネント（共用）
- `src/app/(app)/layout.tsx` — アプリレイアウト
- `src/components/layout/Header.tsx` — ヘッダー
- `src/lib/auth.ts` — 認証モックスタブ
- `src/lib/mockData.ts` — モックデータ（顧客10件）
- `src/types/index.ts` — 共通型定義

## Test plan
- [x] `npm run type-check` パス
- [x] `npm run lint` パス
- [x] `npm run test` パス
- [ ] 顧客一覧が表示されること
- [ ] キーワード検索が機能すること（ST-F-005）
- [ ] 営業ロールで追加・編集ボタンが非表示になること
- [ ] 新規登録・編集が動作すること（UAT-005）

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)